### PR TITLE
Allow use separate attribute and column names 

### DIFF
--- a/sqlakeyset/columns.py
+++ b/sqlakeyset/columns.py
@@ -1,12 +1,11 @@
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
-from sqlalchemy.sql.expression import UnaryExpression
-from sqlalchemy.sql.operators import asc_op, desc_op
-
-from sqlalchemy import asc, column
-
 import sys
 from copy import copy
+
+from sqlalchemy import asc, column
+from sqlalchemy.sql.expression import UnaryExpression
+from sqlalchemy.sql.operators import asc_op, desc_op
 
 PY2 = sys.version_info.major <= 2
 

--- a/sqlakeyset/paging.py
+++ b/sqlakeyset/paging.py
@@ -1,14 +1,14 @@
 from __future__ import unicode_literals
 
-from .columns import parse_clause, OC
-import sqlalchemy
-from sqlalchemy import func
+import sys
 from functools import partial
 
+import sqlalchemy
+from sqlalchemy import func
+from sqlalchemy.orm import class_mapper
+
+from .columns import parse_clause, OC
 from .results import Page, Paging, unserialize_bookmark
-
-import sys
-
 
 PER_PAGE_DEFAULT = 10
 

--- a/sqlakeyset/paging.py
+++ b/sqlakeyset/paging.py
@@ -34,7 +34,6 @@ def orm_page_from_rows(
         column_descriptions,
         backwards=False,
         current_marker=None):
-
     get_marker = partial(
         orm_placemarker_from_row,
         column_descriptions=column_descriptions)
@@ -53,7 +52,6 @@ def core_page_from_rows(
         backwards=False,
         current_marker=None,
         keys=None):
-
     paging = Paging(rows, page_size, ocols, backwards, current_marker, core_placemarker_from_row)
 
     page = Page(paging.rows)
@@ -62,59 +60,66 @@ def core_page_from_rows(
     return page
 
 
+def value_from_thing(thing, desc, ocol):
+    entity = desc['entity']
+    expr = desc['expr']
+
+    try:
+        is_a_table = entity == expr
+    except sqlalchemy.exc.ArgumentError:
+        is_a_table = False
+
+    if is_a_table:  # is a table
+        mapper = class_mapper(desc['type'])
+        if entity.__table__.name == ocol.table_name:
+            prop = mapper.get_property_by_column(ocol.element)
+            return getattr(thing, prop.key)
+        else:
+            raise ValueError
+
+    # is an attribute
+    if hasattr(expr, 'info'):
+        mapper = expr.parent
+        tname = mapper.local_table.description
+
+        if ocol.table_name == tname and ocol.name == expr.name:
+            return thing
+        else:
+            raise ValueError
+
+    # is an attribute with label
+    if ocol.quoted_full_name == OC(expr).full_name:
+        return thing
+    else:
+        raise ValueError
+
+
 def orm_placemarker_from_row(row, ocols, column_descriptions):
-    def value_from_thing(thing, desc, ocol):
-        entity = desc['entity']
-        expr = desc['expr']
-        name = desc['name']
-
-        try:
-            is_a_table = entity == expr
-        except sqlalchemy.exc.ArgumentError:
-            is_a_table = False
-
-        if is_a_table:  # is a table
-            if entity.__table__.name == ocol.table_name:
-                return getattr(thing, ocol.name)
-            else:
-                raise ValueError
-        else:  # is an attribute
-            if hasattr(expr, 'info'):
-                mapper = expr.parent
-                tname = mapper.local_table.description
-
-                if ocol.table_name == tname and ocol.name == name:
-                    return thing
-                else:
-                    raise ValueError
-            else:
-                if ocol.quoted_full_name == OC(expr).full_name:
-                    return thing
-                else:
-                    raise ValueError
-
-    def get_value(ocol):
-        if len(column_descriptions) == 1:
+    cant_find = "can't find value for column {} in the results returned"
+    if len(column_descriptions) == 1:
+        def get_value(ocol):
             desc = column_descriptions[0]
             try:
                 return value_from_thing(row, desc, ocol)
             except ValueError:
                 pass
-        else:
+            raise ValueError(cant_find.format(ocol.full_name))
+    else:
+        def get_value(ocol):
             for thing, desc in zip(row, column_descriptions):
                 try:
                     return value_from_thing(thing, desc, ocol)
                 except ValueError:
                     continue
+            raise ValueError(cant_find.format(ocol.full_name))
 
-        CANT_FIND = "can't find value for column {} in the results returned"
-        raise ValueError(CANT_FIND.format(ocol.full_name))
     return tuple(get_value(x) for x in ocols)
 
 
 def core_placemarker_from_row(row, ocols):
     def get_value(ocol):
         return row[ocol.name]
+
     return tuple(get_value(x) for x in ocols)
 
 
@@ -226,7 +231,6 @@ def select_page(
         after=False,
         before=False,
         page=False):
-
     place, backwards = process_args(after, before, page)
 
     return core_get_page(
@@ -243,7 +247,6 @@ def get_page(
         after=False,
         before=False,
         page=False):
-
     place, backwards = process_args(after, before, page)
 
     return orm_get_page(

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -1,10 +1,9 @@
-from sqlakeyset import OC, Paging, Page
 from pytest import raises
-
-from sqlakeyset import serialize_bookmark
-
-from sqlalchemy import asc, desc
+from sqlalchemy import asc, desc, Column, Integer, String
 from sqlalchemy.sql.expression import nullslast
+
+from sqlakeyset import OC, Paging, Page
+from sqlakeyset import serialize_bookmark
 
 
 def test_oc():
@@ -32,7 +31,39 @@ def test_oc():
     assert repr(n) == '<OC: a DESC NULLS LAST>'
 
 
-def test_paging_objects():
+def general_asserts(p):
+    if not p.backwards:
+        assert p.further == p.next
+    else:
+        assert p.further == p.previous
+
+    if not p.has_further:
+        assert p.current_opposite == (None, not p.backwards)
+
+    assert p.is_full == (len(p.rows) >= p.per_page)
+    assert p.bookmark_further == serialize_bookmark(p.further)
+
+
+def getitem(row, order_cols):
+    return tuple(row[c.name] for c in order_cols)
+
+
+T1 = []
+T2 = [
+    {'id': 1, 'b': 2},
+    {'id': 2, 'b': 1},
+    {'id': 3, 'b': 3}
+]
+T3 = [
+    {'id': 1, 'name': 'test'},
+    {'id': 2, 'name': 'test1'},
+    {'id': 3, 'name': 'test2'},
+    {'id': 4, 'name': 'test3'},
+
+]
+
+
+def test_paging_objects1():
     p = Page(['abc'])
     assert p.one() == 'abc'
 
@@ -42,31 +73,7 @@ def test_paging_objects():
     with raises(RuntimeError):
         Page([]).one()
 
-    def general_asserts(p):
-        if not p.backwards:
-            assert p.further == p.next
-        else:
-            assert p.further == p.previous
-
-        if not p.has_further:
-            assert p.current_opposite == (None, not p.backwards)
-
-        assert p.is_full == (len(p.rows) >= p.per_page)
-        assert p.bookmark_further == \
-            serialize_bookmark(p.further)
-
-    def getitem(row, order_cols):
-        return tuple(row[c.name] for c in order_cols)
-
     ob = [OC(x) for x in ['id', 'b']]
-
-    T1 = []
-
-    T2 = [
-        {'id': 1, 'b': 2},
-        {'id': 2, 'b': 1},
-        {'id': 3, 'b': 3}
-    ]
 
     p = Paging(T1, 10, ob, backwards=False, current_marker=None, get_marker=getitem)
     assert p.next == (None, False)
@@ -74,6 +81,10 @@ def test_paging_objects():
     assert p.previous == (None, True)
     assert not p.is_full
     general_asserts(p)
+
+
+def test_paging_object2_per_page_3():
+    ob = [OC(x) for x in ['id', 'b']]
 
     p = Paging(T2, 3, ob, backwards=False, current_marker=None, get_marker=getitem)
     assert p.next == ((3, 3), False)
@@ -84,6 +95,10 @@ def test_paging_objects():
     assert p.is_full
     general_asserts(p)
 
+
+def test_paging_object2_per_page_2():
+    ob = [OC(x) for x in ['id', 'b']]
+
     p = Paging(T2, 2, ob, backwards=False, current_marker=None, get_marker=getitem)
     assert p.next == ((2, 1), False)
     assert p.has_next
@@ -91,7 +106,26 @@ def test_paging_objects():
 
     assert not p.has_previous
     assert p.previous == ((1, 2), True)
-
     assert p.further == ((2, 1), False)
 
     general_asserts(p)
+
+
+def test_paging_object_text():
+    ob = [OC(Column('id', Integer)), OC(Column('name', String))]
+
+    p = Paging(T3, 2, ob, backwards=False, current_marker=None, get_marker=getitem)
+
+    assert p.rows
+
+    assert p.next == ((2, 'test1'), False)
+    assert p.has_next
+    general_asserts(p)
+
+    assert not p.has_previous
+    assert p.previous == ((1, 'test'), True)
+    assert p.further == ((2, 'test1'), False)
+
+    general_asserts(p)
+
+    assert p.further

--- a/tests/test_paging.py
+++ b/tests/test_paging.py
@@ -19,7 +19,7 @@ BOOK = 't_Book'
 
 class Book(Base):
     __tablename__ = BOOK
-    id = Column(Integer, primary_key=True)
+    id = Column('book_id', Integer, primary_key=True)
     name = Column(String(255))
     a = Column(Integer)
     b = Column(Integer)
@@ -157,7 +157,7 @@ def test_orm_query4(dburl):
 
 
 def test_core(dburl):
-    spec = ['b', 'd', 'id', 'c']
+    spec = ['b', 'd', 'book_id', 'c']
 
     cols = [column(each) for each in spec]
     ob = [OC(x).uo for x in spec]

--- a/tests/test_paging.py
+++ b/tests/test_paging.py
@@ -1,13 +1,12 @@
 import warnings
 
-from sqlbag import temporary_database, S
+import pytest
 from sqlalchemy import select, String, Column, Integer, ForeignKey, column, table, desc
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
+from sqlbag import temporary_database, S
 
 from sqlakeyset import get_page, select_page, serialize_bookmark, unserialize_bookmark, OC, process_args
-
-from pytest import raises
 
 warnings.simplefilter("error")
 
@@ -36,40 +35,34 @@ class Author(Base):
     books = relationship('Book', backref='author')
 
 
-def fixture_setup(dburl):
-    COUNT = 10
+@pytest.fixture(params=['postgresql', 'mysql'])
+def dburl(request):
+    count = 10
+    data = []
 
-    with S(dburl) as s:
-        Base.metadata.create_all(s.connection())
+    for x in range(count):
+        b = Book(name='Book {}'.format(x), a=x, b=x % 2, c=count - x, d=99)
 
-    with S(dburl) as s:
-        for x in range(COUNT):
-            b = Book(
-                name='Book {}'.format(x),
-                a=x,
-                b=x % 2,
-                c=COUNT - x,
-                d=99)
+        if x == 1:
+            b.a = None
+            b.author = Author(name='Willy Shakespeare')
 
-            if x == 1:
-                b.a = None
-                b.author = Author(name='Willy Shakespeare')
-            s.add(b)
+        data.append(b)
+
+    with temporary_database(request.param) as dburl:
+        with S(dburl) as s:
+            Base.metadata.create_all(s.connection())
+            s.add_all(data)
+        yield dburl
 
 
-def check_paging(q=None, selectable=None, s=None):
-    ITEM_COUNTS = range(1, 12)
+def check_paging_orm(q):
+    item_counts = range(1, 12)
 
-    if q is not None:
-        unpaged = q.all()
-    elif selectable is not None:
-        result = s.execute(selectable)
+    unpaged = q.all()
 
-        unpaged = result.fetchall()
-
-    for per_page in ITEM_COUNTS:
-        for backwards in [False, True]:
-
+    for backwards in [False, True]:
+        for per_page in item_counts:
             gathered = []
 
             page = None, backwards
@@ -78,71 +71,105 @@ def check_paging(q=None, selectable=None, s=None):
                 serialized_page = serialize_bookmark(page)
                 page = unserialize_bookmark(serialized_page)
 
-                if q is not None:
-                    method = get_page
-                    args = (q,)
-                elif selectable is not None:
-                    method = select_page
-                    args = (s, selectable)
+                page_with_paging = get_page(q, per_page=per_page, page=serialized_page)
+                paging = page_with_paging.paging
 
-                rows = method(
-                    *args,
-                    per_page=per_page,
-                    page=serialized_page
-                )
-
-                p = rows.paging
-
-                assert p.current == page
-
-                if selectable is not None:
-                    assert rows.keys() == result.keys()
+                assert paging.current == page
 
                 if backwards:
-                    gathered = rows + gathered
+                    gathered = page_with_paging + gathered
                 else:
-                    gathered = gathered + rows
+                    gathered = gathered + page_with_paging
 
-                page = p.further
+                page = paging.further
 
-                if not rows:
-                    assert not p.has_further
-                    assert p.further == p.current
-                    assert p.current_opposite == (None, not p.backwards)
+                if not page_with_paging:
+                    assert not paging.has_further
+                    assert paging.further == paging.current
+                    assert paging.current_opposite == (None, not paging.backwards)
                     break
 
             assert gathered == unpaged
 
 
-def do_orm_tests(dburl):
+def check_paging_core(selectable, s):
+    item_counts = range(1, 12)
+
+    result = s.execute(selectable)
+    unpaged = result.fetchall()
+
+    for backwards in [False, True]:
+        for per_page in item_counts:
+            gathered = []
+
+            page = None, backwards
+
+            while True:
+                serialized_page = serialize_bookmark(page)
+                page = unserialize_bookmark(serialized_page)
+
+                page_with_paging = select_page(s, selectable, per_page=per_page, page=serialized_page)
+                paging = page_with_paging.paging
+
+                assert paging.current == page
+                assert page_with_paging.keys() == result.keys()
+
+                if backwards:
+                    gathered = page_with_paging + gathered
+                else:
+                    gathered = gathered + page_with_paging
+
+                page = paging.further
+
+                if not page_with_paging:
+                    assert not paging.has_further
+                    assert paging.further == paging.current
+                    assert paging.current_opposite == (None, not paging.backwards)
+                    break
+
+            assert gathered == unpaged
+
+
+def test_orm_query1(dburl):
     spec = [desc(Book.b), Book.d, Book.id]
 
     with S(dburl, echo=ECHO) as s:
         q = s.query(Book, Author, Book.id).outerjoin(Author).order_by(*spec)
-        q2 = s.query(Book).order_by(Book.id, Book.name)
-        q3 = s.query(Book.id, Book.name.label('x')).order_by(Book.name, Book.id)
-        q4 = s.query(Book).order_by(Book.name)
-
-        check_paging(q=q)
-        check_paging(q=q2)
-        check_paging(q=q3)
-        check_paging(q=q4)
+        check_paging_orm(q=q)
 
 
-def do_core_tests(dburl):
+def test_orm_query2(dburl):
+    with S(dburl, echo=ECHO) as s:
+        q = s.query(Book).order_by(Book.id, Book.name)
+        check_paging_orm(q=q)
+
+
+def test_orm_query3(dburl):
+    with S(dburl, echo=ECHO) as s:
+        q = s.query(Book.id, Book.name.label('x')).order_by(Book.name, Book.id)
+        check_paging_orm(q=q)
+
+
+def test_orm_query4(dburl):
+    with S(dburl, echo=ECHO) as s:
+        q = s.query(Book).order_by(Book.name)
+        check_paging_orm(q=q)
+
+
+def test_core(dburl):
     spec = ['b', 'd', 'id', 'c']
 
     cols = [column(each) for each in spec]
     ob = [OC(x).uo for x in spec]
 
-    with S(dburl, echo=ECHO) as s:
-        selectable = select(
-            cols,
-            from_obj=[table('t_Book')],
-            whereclause=column('d') == 99,
-            order_by=ob)
+    selectable = select(
+        cols,
+        from_obj=[table('t_Book')],
+        whereclause=column('d') == 99,
+        order_by=ob)
 
-        check_paging(selectable=selectable, s=s)
+    with S(dburl, echo=ECHO) as s:
+        check_paging_core(selectable=selectable, s=s)
 
 
 def test_args():
@@ -150,11 +177,11 @@ def test_args():
     assert process_args(after=(1, 2)) == ((1, 2), False)
     assert process_args(before=(1, 2)) == ((1, 2), True)
 
-    with raises(ValueError):
+    with pytest.raises(ValueError):
         process_args(before=(1, 2), after=(1, 2))
-    with raises(ValueError):
+    with pytest.raises(ValueError):
         process_args(before=(1, 2), page=(1, 2))
-    with raises(ValueError):
+    with pytest.raises(ValueError):
         process_args(after=(1, 2), page=(1, 2))
     assert process_args(False, False, False) == (None, False)
 
@@ -173,11 +200,3 @@ def test_bookmarks():
     assert serialize_bookmark(last) == '<'
     assert twoway(first)
     assert twoway(last)
-
-
-def test_paging():
-    for db in ['postgresql', 'mysql']:
-        with temporary_database(db) as dburl:
-            fixture_setup(dburl)
-            do_orm_tests(dburl)
-            do_core_tests(dburl)


### PR DESCRIPTION
Hello, currently sqlakeyset not allow use separate names for property and column names.
```
class Book(Base):
    id = sa.Column('book_id', Integer, primary_key=True)
    ...
```
Main problem in getattr, well i'm rewrited code for use sa.mapper object.

Also rewrite tests, for more granular runs.