### PR TITLE
Joined inheritance

### DIFF
--- a/sqlakeyset/paging.py
+++ b/sqlakeyset/paging.py
@@ -6,6 +6,7 @@ from functools import partial
 import sqlalchemy
 from sqlalchemy import func
 from sqlalchemy.orm import class_mapper, Mapper
+from sqlalchemy.orm.exc import UnmappedColumnError
 
 from .columns import parse_clause, OC
 from .results import Page, Paging, unserialize_bookmark
@@ -78,10 +79,10 @@ def value_from_thing(thing, desc, ocol):
 
     if is_a_table:  # is a table
         mapper = class_mapper(desc['type'])
-        if entity.__table__.name == ocol.table_name:
+        try:
             prop = mapper.get_property_by_column(ocol.element)
             return getattr(thing, prop.key)
-        else:
+        except UnmappedColumnError:
             raise ValueError
 
     # is an attribute

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -21,6 +21,8 @@ def test_oc():
     assert a.is_ascending
     assert not b.is_ascending
     assert not n.reversed.reversed.is_ascending
+    assert n.reversed.is_ascending
+    assert not n.is_ascending # make sure reversed doesn't modify in-place
     assert str(a.element) == str(b.element) == str(n.element)
     assert str(a) == str(b.reversed)
     assert str(n.reversed.reversed) == str(n)


### PR DESCRIPTION
This should fix #7. Change is very simple: rather than testing table names for equality, just trust the ORM to raise an error if it can't correctly map the column to an attribute name.