### PR TITLE
Merry Christmas!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ nosetests.xml
 
 .cache
 .python-version
+
+.vim

--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,20 @@ Limitations
 
 - **Golden Rule:** Always ensure your keysets are unique per row. If you violate this condition you risk skipped rows and other nasty problems. The simplest way to do this is to always include your primary key column(s) at the end of your ordering columns.
 
+- Any rows containing null values in their keysets **will be omitted from the results**, so your ordering columns should be ``NOT NULL``. (This is a consequence of the fact that comparisons against ``NULL`` are always false in SQL.) This may change in the future if we work out an alternative implementation; but for now we recommend using ``coalesce`` as a workaround:
+
+.. code-block:: python
+
+    from sqlakeyset import get_page
+    from sqlalchemy import func
+    from sqlbag import S
+    from models import Book
+    with S('postgresql:///books') as s:
+        # If Book.cost can be NULL:
+        q = s.query(Book).order_by(func.coalesce(Book.cost, 0), Book.id)
+        # page1 will start with books where cost is null:
+        page1 = get_page(q, per_page=20)
+
 - If you're using the in-built keyset serialization, this only handles basic data/column types so far (strings, ints, floats, datetimes, dates, booleans, and a few others). The serialization can be extended to serialize more advanced types as necessary (documentation on this is forthcoming).
 
 

--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,7 @@ And the last page:
 Keyset Serialization
 --------------------
 
-You will probably want to turn these keysets/bookmarks for passing around. ``sqlakeyset`` includes code to do this. To get a serialized bookmark, just add ``bookmark_`` to the name of the property that holds the keyset you want.
+You will probably want to turn these keysets/bookmarks into strings for passing around. ``sqlakeyset`` includes code to do this. To get a serialized bookmark, just add ``bookmark_`` to the name of the property that holds the keyset you want.
 
 Most commonly you'll want ``next`` and ``previous``, so:
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1,0 +1,27 @@
+API Documentation
+-----------------
+
+.. currentmodule:: sqlakeyset
+
+Pagination API
+^^^^^^^^^^^^^^
+
+.. autofunction:: get_page
+.. autofunction:: select_page
+
+Pagination Results
+^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: Page
+   :members:
+.. autoclass:: Paging
+   :members:
+
+Bookmark Serialization
+^^^^^^^^^^^^^^^^^^^^^^
+
+In most use cases, you shouldn't need to call these directly - bookmarks can be obtained by calling the `bookmark_`-prefixed methods on :class:`Page` objects, and can be passed directly as the `page`, `after` or `before` parameters to :func:`get_page` and :func:`select_page`.
+
+.. autofunction:: serialize_bookmark
+.. autofunction:: unserialize_bookmark
+

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,0 +1,57 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'sqlakeyset'
+copyright = '2019, Robert Lechte'
+author = 'Robert Lechte'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.intersphinx'
+]
+
+intersphinx_mapping = {
+    'sqlalchemy': ('https://docs.sqlalchemy.org/en/13/', None)
+}
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -29,7 +29,8 @@ author = 'Robert Lechte'
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
-    'sphinx.ext.intersphinx'
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.viewcode',
 ]
 
 intersphinx_mapping = {
@@ -49,7 +50,7 @@ exclude_patterns = []
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,8 +1,3 @@
-.. sqlakeyset documentation master file, created by
-   sphinx-quickstart on Sun Dec 22 16:07:13 2019.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 Welcome to sqlakeyset's documentation!
 ======================================
 
@@ -10,23 +5,8 @@ Welcome to sqlakeyset's documentation!
    :maxdepth: 2
    :caption: Contents:
 
-Paging API
-----------
-
-.. automodule:: sqlakeyset
-    :members:
-
-Internal Developer Documentation
---------------------------------
-
-.. automodule:: sqlakeyset.paging
-    :members:
-
-.. automodule:: sqlakeyset.columns
-    :members:
-
-.. automodule:: sqlakeyset.results
-    :members:
+   api
+   internals
 
 
 Indices and tables

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,0 +1,37 @@
+.. sqlakeyset documentation master file, created by
+   sphinx-quickstart on Sun Dec 22 16:07:13 2019.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to sqlakeyset's documentation!
+======================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+Paging API
+----------
+
+.. automodule:: sqlakeyset
+    :members:
+
+Internal Developer Documentation
+--------------------------------
+
+.. automodule:: sqlakeyset.paging
+    :members:
+
+.. automodule:: sqlakeyset.columns
+    :members:
+
+.. automodule:: sqlakeyset.results
+    :members:
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/doc/source/internals.rst
+++ b/doc/source/internals.rst
@@ -1,0 +1,18 @@
+Internal Documentation
+----------------------
+
+This page documents functions and classes that are used internally in
+sqlakeyset.
+
+sqlakeyset.paging
+^^^^^^^^^^^^^^^^^
+
+.. automodule:: sqlakeyset.paging
+    :members:
+    :exclude-members: get_page, select_page
+
+sqlakeyset.columns
+^^^^^^^^^^^^^^^^^^
+
+.. automodule:: sqlakeyset.columns
+    :members:

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,5 +19,6 @@ pymysql
 tox
 
 sphinx
+sphinx_rtd_theme
 wheel
 twine

--- a/sqlakeyset/__init__.py
+++ b/sqlakeyset/__init__.py
@@ -1,5 +1,4 @@
-from .columns import OC
-from .paging import get_page, select_page, process_args
+from .paging import get_page, select_page
 from .results import serialize_bookmark, unserialize_bookmark, Page, Paging
 
 __all__ = [

--- a/sqlakeyset/__init__.py
+++ b/sqlakeyset/__init__.py
@@ -1,15 +1,12 @@
-
 from .columns import OC
 from .paging import get_page, select_page, process_args
 from .results import serialize_bookmark, unserialize_bookmark, Page, Paging
 
 __all__ = [
-    'OC',
     'get_page',
     'select_page',
     'serialize_bookmark',
     'unserialize_bookmark',
     'Page',
     'Paging',
-    'process_args'
 ]

--- a/sqlakeyset/columns.py
+++ b/sqlakeyset/columns.py
@@ -92,7 +92,7 @@ class OC:
         """An :class:`OC` representing the same column ordering, but reversed."""
         new_uo = _reverse_order_direction(self.uo)
         if new_uo is None:
-            raise ValueError
+            raise ValueError # pragma: no cover
         return OC(new_uo)
 
     def __str__(self):
@@ -108,7 +108,7 @@ def strip_labels(el):
         try:
             el = el.element
         except AttributeError:
-            raise ValueError
+            raise ValueError # pragma: no cover
     return el
 
 
@@ -129,7 +129,7 @@ def _get_order_direction(x):
         if el is None:
             return None
         x = el
-    raise Exception(_WRAPPING_OVERFLOW)
+    raise Exception(_WRAPPING_OVERFLOW) # pragma: no cover
 
 
 def _reverse_order_direction(ce):
@@ -155,7 +155,7 @@ def _reverse_order_direction(ce):
             # need to clone another level deeper.
             x._copy_internals()
             x = x.element
-    raise Exception(_WRAPPING_OVERFLOW)
+    raise Exception(_WRAPPING_OVERFLOW) # pragma: no cover
 
 
 def _remove_order_direction(ce):
@@ -193,7 +193,7 @@ def _remove_order_direction(ce):
             # need to clone another level deeper.
             x._copy_internals()
             x = x.element
-    raise Exception(_WRAPPING_OVERFLOW)
+    raise Exception(_WRAPPING_OVERFLOW) # pragma: no cover
 
 
 class MappedOrderColumn:
@@ -213,7 +213,7 @@ class MappedOrderColumn:
 
     def get_from_row(self, internal_row):
         """Extract the value of this ordering column from a result row."""
-        raise NotImplementedError
+        raise NotImplementedError # pragma: no cover
 
     @property
     def ob_clause(self):

--- a/sqlakeyset/columns.py
+++ b/sqlakeyset/columns.py
@@ -304,7 +304,7 @@ def derive_order_key(ocol, desc, index):
 
     if isinstance(expr, Bundle):
         for key, col in expr.columns.items():
-            if strip_labels(col) == ocol.comparable_value:
+            if strip_labels(col).compare(ocol.comparable_value):
                 return AttributeColumn(ocol, index, key)
 
     try:

--- a/sqlakeyset/columns.py
+++ b/sqlakeyset/columns.py
@@ -1,3 +1,4 @@
+"""The OC class and supporting functions to manipulate ordering columns."""
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
 import sys
@@ -5,9 +6,14 @@ import sys
 from sqlalchemy import asc, column
 from sqlalchemy.sql.expression import UnaryExpression, Label
 from sqlalchemy.sql.elements import _label_reference
-from sqlalchemy.sql.operators import asc_op, desc_op
+from sqlalchemy.sql.operators import asc_op, desc_op, nullsfirst_op, nullslast_op
 
-_COL_WRAPPERS = (UnaryExpression, Label, _label_reference)
+_LABELLED = (Label, _label_reference)
+_ORDER_MODIFIERS = (asc_op, desc_op, nullsfirst_op, nullslast_op)
+_WRAPPING_DEPTH = 1000
+_WRAPPING_OVERFLOW = ("Maximum element wrapping depth reached; there's "
+                      "probably a circularity in sqlalchemy that "
+                      "sqlakeyset doesn't know how to handle.")
 
 PY2 = sys.version_info.major <= 2
 
@@ -17,32 +23,11 @@ if not PY2:
 
 def parse_clause(clause):
     return [OC(c) for c in clause]
-
-
-def _get_order_direction(x):
-    """
-    Given a ColumnElement, find and return its ordering direction
-    (ASC or DESC) if it has one.
-
-    :param x: a :class:`sqlalchemy.sql.expression.ColumnElement`
-    :return: `asc_op`, `desc_op` or `None`
-    """
-    try:
-        for _ in range(1000):
-            try:
-                if x.modifier in (asc_op, desc_op):
-                    return x.modifier == asc_op
-            except AttributeError:
-                pass
-            x = x.element
-        raise Exception("Insane element wrapping depth reached; there's "
-                        "probably a sqlalchemy recursion here that "
-                        "sqlakeyset doesn't know how to handle.")
-    except AttributeError:
-        return None
-
+   
 
 class OC(object):
+    """Wrapper class for ordering columns; i.e. ColumnElements appearing in
+    the ORDER BY clause of a query we are paging."""
     def __init__(self, x):
         if isinstance(x, unicode):
             x = column(x)
@@ -65,40 +50,120 @@ class OC(object):
 
     @property
     def element(self):
-        x = self.uo
-        while isinstance(x, UnaryExpression):
-            x = x.element
-        return x
+        """Get a copy of the wrapped column with ordering modifier removed."""
+        return _remove_order_direction(self.uo)
+
+    @property
+    def comparable_value(self):
+        """Get a copy of the wrapped column that is suitable for incorporating
+        in a ROW(...)>ROW(...) comparision; i.e. with ordering modifiers and
+        labels removed."""
+        el = self.element
+        while isinstance(el, _LABELLED):
+            try:
+                el = el.element
+            except AttributeError:
+                raise ValueError
+        return el
 
     @property
     def is_ascending(self):
         d = _get_order_direction(self.uo)
         if d is None:
             raise ValueError  # pragma: no cover
-        return d
+        return d == asc_op
 
     @property
     def reversed(self):
-        # It seems this "clone" is only one level deep; so we need to call
-        # _copy_internals for each level we descend.
-        x = copied = self.uo._clone()
-
-        while isinstance(x, _COL_WRAPPERS):
-            if getattr(x, 'modifier', None) in (asc_op, desc_op):
-                if x.modifier == asc_op:
-                    x.modifier = desc_op
-                else:
-                    x.modifier = asc_op
-                return OC(copied)
-            else:
-                # Since we're going to change something inside x.element, we
-                # need to clone another level deeper.
-                x._copy_internals()
-                x = x.element
-        raise ValueError  # pragma: no cover
+        """Get an OC representing the same column ordering, but reversed."""
+        # TODO: swapping asc/desc does NOT exactly reverse the order when nulls
+        # are present. We should use NULLS FIRST/NULLS LAST appropriately, at
+        # least when the SQL dialect supports them.
+        new_uo = _reverse_order_direction(self.uo)
+        if new_uo is None:
+            raise ValueError
+        return OC(new_uo)
 
     def __str__(self):
         return str(self.uo)
 
     def __repr__(self):
         return '<OC: {}>'.format(str(self))
+
+
+def _get_order_direction(x):
+    """
+    Given a ColumnElement, find and return its ordering direction
+    (ASC or DESC) if it has one.
+
+    :param x: a :class:`sqlalchemy.sql.expression.ColumnElement`
+    :return: `asc_op`, `desc_op` or `None`
+    """
+    for _ in range(_WRAPPING_DEPTH):
+        mod = getattr(x, 'modifier', None)
+        if mod in (asc_op, desc_op):
+            return mod
+
+        el = getattr(x, 'element', None)
+        if el is None:
+            return None
+        x = el
+    raise Exception(_WRAPPING_OVERFLOW)
+
+def _reverse_order_direction(ce):
+    """
+    Given a ColumnElement, return a copy with its ordering direction
+    (ASC or DESC) reversed (if it has one).
+
+    Does NOT yet handle NULLS FIRST/LAST correctly.
+
+    :param ce: a :class:`sqlalchemy.sql.expression.ColumnElement`
+    """
+    x = copied = ce._clone()
+    for _ in range(_WRAPPING_DEPTH):
+        mod = getattr(x, 'modifier', None)
+        if mod in (asc_op, desc_op):
+            if mod == asc_op:
+                x.modifier = desc_op
+            else:
+                x.modifier = asc_op
+            return copied
+        else:
+            if not hasattr(x, 'element'):
+                return copied
+            # Since we're going to change something inside x.element, we
+            # need to clone another level deeper.
+            x._copy_internals()
+            x = x.element
+    raise Exception(_WRAPPING_OVERFLOW)
+
+
+def _remove_order_direction(ce):
+    """
+    Given a ColumnElement, return a copy with its ordering modifiers
+    (ASC/DESC, NULLS FIRST/LAST) removed (if it has any).
+
+    :param ce: a :class:`sqlalchemy.sql.expression.ColumnElement`
+    """
+    x = copied = ce._clone()
+    parent = None
+    for _ in range(_WRAPPING_DEPTH):
+        mod = getattr(x, 'modifier', None)
+        if mod in _ORDER_MODIFIERS:
+            x._copy_internals()
+            if parent is None:
+                # The modifier was at the top level; so just take the child.
+                copied = x = x.element
+            else:
+                # Remove this link from the wrapping element chain and return
+                # the top-level expression.
+                parent.element = x = x.element
+        else:
+            if not hasattr(x, 'element'):
+                return copied
+            parent = x
+            # Since we might change something inside x.element, we
+            # need to clone another level deeper.
+            x._copy_internals()
+            x = x.element
+    raise Exception(_WRAPPING_OVERFLOW)

--- a/sqlakeyset/paging.py
+++ b/sqlakeyset/paging.py
@@ -213,7 +213,7 @@ def core_page_from_rows(
 
 def paging_condition(ordering_columns, place):
     if len(ordering_columns) != len(place):
-        raise ValueError('bad paging value')
+        raise ValueError('bad paging value') # pragma: no cover
 
     def swapped_if_descending(c, value):
         if not c.is_ascending:

--- a/sqlakeyset/paging.py
+++ b/sqlakeyset/paging.py
@@ -1,28 +1,37 @@
 """Main paging interface and implementation."""
-from __future__ import unicode_literals
-
-import sys
-from functools import partial
-
-import sqlalchemy
-from sqlalchemy import func
-from sqlalchemy.orm import class_mapper, Mapper
+from sqlalchemy import func, select
 from sqlalchemy.util import lightweight_named_tuple
-from sqlalchemy.exc import ArgumentError
-from sqlalchemy.orm.exc import UnmappedColumnError
 
-from .columns import parse_clause, OC
+from .columns import parse_clause, find_order_key
 from .results import Page, Paging, unserialize_bookmark
 
 PER_PAGE_DEFAULT = 10
 
-PY2 = sys.version_info[0] == 2
+def result_row_type(query):
+    """Return the type constructor for rows that would be returned by a given
+    query; or the identity function for queries that return a single entity.
 
-if not PY2:
-    unicode = str
+    :param query: The query to inspect.
+    :type query: :class:`sqlalchemy.orm.Query`.
+    :returns: either a named tuple type or the identity."""
+
+    if query.is_single_entity:
+        return lambda x: x[0]
+    labels = [e._label_name for e in query._entities]
+    return lightweight_named_tuple("result", labels)
 
 
 def where_condition_for_page(ordering_columns, place):
+    """Construct the SQL condition required to restrict a query to the desired
+    page.
+
+    :param ordering_columns: The query's ordering columns
+    :type ordering_columns: list(:class:`.columns.OC`)
+    :param place: The starting position for the page
+    :type place: tuple
+    :returns: An SQLAlchemy expression suitable for use in ``.where()`` or
+        ``.filter()``.
+    """
     row, place_row = paging_condition(ordering_columns, place)
     if len(row) == 1:
         condition = row[0] > place_row[0]
@@ -31,120 +40,35 @@ def where_condition_for_page(ordering_columns, place):
     return condition
 
 
-def orm_clean_row(row, key_entities, result_type):
-    if key_entities:
-        n = len(row) - len(key_entities)
-        return result_type(row[:n]), row[n:]
-    else:
-        return row, ()
-
-
 def orm_page_from_rows(
         rows,
         page_size,
         ocols,
-        column_descriptions,
-        key_entities,
+        mapped_ocols,
+        extra_entities,
         result_type,
         backwards=False,
         current_marker=None):
+    """Turn a raw page of results for an ORM query (as obtained by
+    :func:`orm_get_page`) into a :class:`Page` for external consumers."""
+
     # orm_get_page might have added some extra columns to the query in order
-    # to get the keys for the bookmark. Here, we extract those keys into a
-    # dict, and then trim the rows back to their original format.
-    rows_and_keys = [orm_clean_row(row, key_entities, result_type)
-                     for row in rows]
-    rows = [r for r, _ in rows_and_keys]
-    row_keys=dict(rows_and_keys)
+    # to get the keys for the bookmark. Here, we split the rows back to the
+    # requested data and the ordering keys.
+    def clean_row(row):
+        """Trim off the extra entities."""
+        N = len(row) - len(extra_entities)
+        return result_type(row[:N])
 
-    get_marker = partial(
-        orm_placemarker_from_row,
-        column_descriptions=column_descriptions,
-        key_entities=key_entities,
-        row_keys=row_keys,
-    )
-
-    paging = Paging(rows, page_size, ocols, backwards, current_marker, get_marker)
+    out_rows = [clean_row(row) for row in rows]
+    key_rows = [tuple(col.get_from_row(row) for col in mapped_ocols)
+                for row in rows]
+    paging = Paging(out_rows, page_size, ocols, backwards,
+                    current_marker, get_marker=None, markers=key_rows)
 
     page = Page(paging.rows)
     page.paging = paging
     return page
-
-
-def core_page_from_rows(
-        rows,
-        page_size,
-        ocols,
-        backwards=False,
-        current_marker=None,
-        keys=None):
-    paging = Paging(rows, page_size, ocols, backwards, current_marker, core_placemarker_from_row)
-
-    page = Page(paging.rows)
-    page.paging = paging
-    page._keys = keys
-    return page
-
-
-def value_from_thing(thing, desc, ocol):
-    entity = desc['entity']
-    expr = desc['expr']
-
-    try:
-        # We need to coerce this to a bool now to catch TypeErrors in certain
-        # cases where (entity == expr) is a SQLAlchemy expression with no
-        # truth value.
-        is_a_table = bool(entity == expr)
-    except (sqlalchemy.exc.ArgumentError, TypeError):
-        is_a_table = False
-
-    if isinstance(expr, Mapper) and expr.class_ == entity:
-        # Is a table mapper. Just treat as a table.
-        is_a_table = True
-
-    if is_a_table:  # is a table
-        mapper = class_mapper(desc['type'])
-        try:
-            prop = mapper.get_property_by_column(ocol.element)
-            return getattr(thing, prop.key)
-        except UnmappedColumnError:
-            raise ValueError
-
-    # is an attribute
-    if hasattr(expr, 'info'):
-        mapper = expr.parent
-        tname = mapper.local_table.description
-
-        if ocol.table_name == tname and ocol.name == expr.name:
-            return thing
-        else:
-            raise ValueError
-
-    # is an attribute with label
-    if ocol.quoted_full_name == OC(expr).full_name:
-        return thing
-    else:
-        raise ValueError
-
-
-def orm_placemarker_from_row(row, ocols, column_descriptions,
-                             key_entities, row_keys):
-    cant_find = "can't find value for column {} in the results returned"
-    one_entity = len(column_descriptions) == 1
-    def get_value(ocol):
-        if ocol in key_entities:
-            # We added this ocol to the query explicitly; so we can just go 
-            # and get it.
-            index, _ = key_entities[ocol]
-            return row_keys[row][index]
-        for thing, desc in zip([row] if one_entity else row,
-                               column_descriptions):
-            try:
-                return value_from_thing(thing, desc, ocol)
-            except ValueError:
-                continue
-        raise ValueError(cant_find.format(ocol.full_name))
-
-    return tuple(get_value(x) for x in ocols)
 
 
 def core_placemarker_from_row(row, ocols):
@@ -154,89 +78,42 @@ def core_placemarker_from_row(row, ocols):
     return tuple(get_value(x) for x in ocols)
 
 
-def orm_key_entity(ocol, column_descriptions):
-    """Determine whether the value of `ocol` can be derived from a result row
-    described by `column_descriptions`. If so, return None. If not, return an
-    extra column expression containing the value of `ocol`."""
-    for desc in column_descriptions:
-        entity = desc['entity']
-        expr = desc['expr']
+def core_page_from_rows(
+        rows,
+        page_size,
+        ocols,
+        backwards=False,
+        current_marker=None,
+        keys=None):
+    """Turn a raw page of results for an SQLAlchemy Core query (as obtained by
+    :func:`core_get_page`) into a :class:`Page` for external consumers."""
+    paging = Paging(rows, page_size, ocols, backwards, current_marker, core_placemarker_from_row)
 
-        try:
-            is_a_table = bool(entity == expr)
-        except (sqlalchemy.exc.ArgumentError, TypeError):
-            is_a_table = False
-
-        if isinstance(expr, Mapper) and expr.class_ == entity:
-            is_a_table = True
-
-        if is_a_table:  # is a table
-            mapper = class_mapper(desc['type'])
-            try:
-                prop = mapper.get_property_by_column(ocol.element)
-                return None
-            except UnmappedColumnError:
-                pass
-
-        # is an attribute
-        if hasattr(expr, 'info'):
-            mapper = expr.parent
-            tname = mapper.local_table.description
-            if ocol.table_name == tname and ocol.name == expr.name:
-                return None
-
-        # is an attribute with label
-        try:
-            if ocol.quoted_full_name == OC(expr).full_name:
-                return None
-        except ArgumentError:
-            pass
-
-    # Couldn't find an existing column in the query from which we can
-    # determine this ordering column; so we need to add one.
-    return ocol.element
-
-
-def orm_key_entities(ocols, column_descriptions, starting_index=0):
-    es = ((starting_index + i, c, orm_key_entity(c, column_descriptions))
-          for i, c in enumerate(ocols))
-    return {c: (i,e) for i, c, e in es if e is not None}
-
-
-def orm_result_type(query):
-    labels = [e._label_name for e in query._entities]
-
-    if len(labels) > 1:
-        return lightweight_named_tuple("result", labels)
-    else:
-        return lambda x: x[0]
+    page = Page(paging.rows)
+    page.paging = paging
+    page._keys = keys
+    return page
 
 
 def orm_get_page(q, per_page, place, backwards):
     ob_clause = q.selectable._order_by_clause
-
-    order_cols = parse_clause(ob_clause)
-
-    if backwards:
-        order_cols = [c.reversed for c in order_cols]
-
-    clauses = [c.uo for c in order_cols]
-    q = q.order_by(False).order_by(*clauses)
+    result_type = result_row_type(q)
     column_descriptions = q.column_descriptions
 
-    # We might have to add some entities to the query in order to get our
-    # bookmark; so first save the result type of the original query so we can
-    # restore it later.
-    # TODO: is there a cleaner way to do this? Perhaps similarly to how sa's
-    # joinedload, etc, works?
-    result_type = orm_result_type(q)
-    # Then work out which entities we need to add, and add them.
-    key_entities = orm_key_entities(order_cols, q.column_descriptions)
-    existing_entities = (e.expr for e in q._entities)
-    q = q.with_entities(
-        *existing_entities,
-        *(key_ent for (_, key_ent) in key_entities.values())
-    )
+    order_cols = parse_clause(ob_clause)
+    if backwards:
+        order_cols = [c.reversed for c in order_cols]
+    mapped_ocols = [find_order_key(ocol, column_descriptions)
+                    for ocol in order_cols]
+
+    clauses = [col.ob_clause for col in mapped_ocols]
+    q = q.order_by(False).order_by(*clauses).only_return_tuples(True)
+
+    extra_entities = [col.extra_entity for col in mapped_ocols
+                      if k.extra_entity is not None]
+    if extra_entities:
+        existing_entities = (e.expr for e in q._entities)
+        q = q.with_entities(*existing_entities, *extra_entities)
 
     if place:
         condition = where_condition_for_page(order_cols, place)
@@ -248,16 +125,14 @@ def orm_get_page(q, per_page, place, backwards):
         else:
             q = q.filter(condition)
 
-    q = q.limit(per_page + 1)
-
     rows = q.all()
 
     page = orm_page_from_rows(
         rows,
         per_page,
         order_cols,
-        column_descriptions,
-        key_entities,
+        mapped_ocols,
+        extra_entities,
         result_type,
         backwards,
         current_marker=place)
@@ -312,7 +187,7 @@ def paging_condition(ordering_columns, place):
 
 
 def process_args(after=False, before=False, page=False):
-    if isinstance(page, unicode):
+    if isinstance(page, str):
         page = unserialize_bookmark(page)
 
     if before is not False and after is not False:
@@ -343,6 +218,23 @@ def select_page(
         after=False,
         before=False,
         page=False):
+    """Get a page of results from a SQLAlchemy Core selectable.
+
+    Specify no more than one of the arguments ``page``, ``after`` or
+    ``before``. If none is provided, the first page is returned.
+
+    :param s: :class:`sqlalchemy.engine.Connection` or
+        :class:`sqlalchemy.orm.session.Session` to use to execute the query.
+    :param selectable: The source selectable.
+    :param per_page: The (maximum) number of rows on the page.
+    :type per_page: int, optional.
+    :param page: a ``(keyset, backwards)`` pair or string bookmark describing
+        the page to get.
+    :param after: if provided, the page will consist of the rows immediately
+        following the specified keyset.
+    :param before: if provided, the page will consist of the rows immediately
+        preceding the specified keyset.
+    """
     place, backwards = process_args(after, before, page)
 
     return core_get_page(
@@ -354,15 +246,30 @@ def select_page(
 
 
 def get_page(
-        q,
+        query,
         per_page=PER_PAGE_DEFAULT,
-        after=False,
-        before=False,
+        after=False, before=False,
         page=False):
+    """Get a page of results for an ORM query.
+
+    Specify no more than one of the arguments ``page``, ``after`` or
+    ``before``. If none is provided, the first page is returned.
+
+    :param query: The source query.
+    :type query: :class:`sqlalchemy.orm.Query`.
+    :param per_page: The (maximum) number of rows on the page.
+    :type per_page: int, optional.
+    :param page: a ``(keyset, backwards)`` pair or string bookmark describing 
+        the page to get.
+    :param after: if provided, the page will consist of the rows immediately
+        following the specified keyset.
+    :param before: if provided, the page will consist of the rows immediately
+        preceding the specified keyset.
+    """
     place, backwards = process_args(after, before, page)
 
     return orm_get_page(
-        q,
+        query,
         per_page,
         place,
         backwards)

--- a/sqlakeyset/paging.py
+++ b/sqlakeyset/paging.py
@@ -134,6 +134,8 @@ def orm_get_page(q, per_page, place, backwards):
         else:
             q = q.filter(condition)
 
+    q = q.limit(per_page + 1) # 1 extra to check if there's a further page
+
     rows = q.all()
 
     page = orm_page_from_rows(

--- a/sqlakeyset/paging.py
+++ b/sqlakeyset/paging.py
@@ -1,5 +1,8 @@
 """Main paging interface and implementation."""
+from copy import copy
+
 from sqlalchemy import func
+from sqlalchemy.orm.query import Query
 from sqlalchemy.util import lightweight_named_tuple
 
 from .columns import parse_clause, find_order_key
@@ -7,7 +10,7 @@ from .results import Page, Paging, unserialize_bookmark
 
 PER_PAGE_DEFAULT = 10
 
-def result_row_type(query):
+def orm_result_type(query):
     """Return the type constructor for rows that would be returned by a given
     query; or the identity function for queries that return a single entity.
 
@@ -40,19 +43,16 @@ def where_condition_for_page(ordering_columns, place):
     return condition
 
 
-def orm_page_from_rows(
-        rows,
-        page_size,
-        ocols,
-        mapped_ocols,
-        extra_entities,
-        result_type,
-        keys,
-        backwards=False,
-        current_marker=None):
+def orm_page_from_rows(paging_result,
+                       result_type,
+                       page_size,
+                       backwards=False,
+                       current_marker=None):
     """Turn a raw page of results for an ORM query (as obtained by
     :func:`orm_get_page`) into a :class:`.results.Page` for external
     consumers."""
+
+    ocols, mapped_ocols, extra_entities, rows, keys = paging_result
 
     # orm_get_page might have added some extra columns to the query in order
     # to get the keys for the bookmark. Here, we split the rows back to the
@@ -66,49 +66,22 @@ def orm_page_from_rows(
     key_rows = [tuple(col.get_from_row(row) for col in mapped_ocols)
                 for row in rows]
     paging = Paging(out_rows, page_size, ocols, backwards,
-                    current_marker, get_marker=None, markers=key_rows)
+                    current_marker, markers=key_rows)
 
     page = Page(paging.rows, paging, keys=keys)
     return page
 
 
-def core_placemarker_from_row(row, ocols):
-    def get_value(ocol):
-        return row[ocol.name]
+def perform_paging(q, per_page, place, backwards, orm=True, s=None):
+    if orm:
+        selectable = q.selectable
+        column_descriptions = q.column_descriptions
+        keys = [e._label_name for e in q._entities]
+    else:
+        selectable = q
+        column_descriptions = q._raw_columns
 
-    return tuple(get_value(x) for x in ocols)
-
-
-def core_page_from_rows(
-        rows,
-        page_size,
-        ocols,
-        backwards=False,
-        current_marker=None,
-        keys=None):
-    """Turn a raw page of results for an SQLAlchemy Core query (as obtained by
-    :func:`.core_get_page`) into a :class:`.Page` for external consumers."""
-    paging = Paging(rows, page_size, ocols, backwards, current_marker, core_placemarker_from_row)
-
-    page = Page(paging.rows, paging, keys=keys)
-    return page
-
-
-def orm_get_page(q, per_page, place, backwards):
-    """Get a page from an SQLAlchemy ORM query.
-
-    :param q: The :class:`sqlalchemy.orm.query.Query` to paginate
-    :param per_page: Number of rows per page.
-    :param place: Keyset representing the place after which to start the page.
-    :param backwards: If ``True``, reverse pagination direction.
-    :returns: :class:`Page`
-    """
-
-    ob_clause = q.selectable._order_by_clause
-    result_type = result_row_type(q)
-    keys = [e._label_name for e in q._entities]
-    column_descriptions = q.column_descriptions
-
+    ob_clause = selectable._order_by_clause
     order_cols = parse_clause(ob_clause)
     if backwards:
         order_cols = [c.reversed for c in order_cols]
@@ -116,38 +89,64 @@ def orm_get_page(q, per_page, place, backwards):
                     for ocol in order_cols]
 
     clauses = [col.ob_clause for col in mapped_ocols]
-    q = q.order_by(False).order_by(*clauses).only_return_tuples(True)
+    q = q.order_by(None).order_by(*clauses)
+    if orm:
+        q = q.only_return_tuples(True)
 
     extra_entities = [col.extra_entity for col in mapped_ocols
                       if col.extra_entity is not None]
     if extra_entities:
-        existing_entities = (e.expr for e in q._entities)
-        q = q.with_entities(*existing_entities, *extra_entities)
+        if orm:
+            existing_entities = (e.expr for e in q._entities)
+            q = q.with_entities(*existing_entities, *extra_entities)
+        else:
+            for e in extra_entities:
+                q.append_column(e)
 
     if place:
         condition = where_condition_for_page(order_cols, place)
         # For aggregate queries, paging condition is applied *after*
         # aggregation. In SQL this means we need to use HAVING instead of
         # WHERE.
-        if q._group_by:
+        groupby = selectable._group_by_clause
+        if groupby is not None and len(groupby) > 0:
             q = q.having(condition)
-        else:
+        elif orm:
             q = q.filter(condition)
+        else:
+            q = q.where(condition)
 
     q = q.limit(per_page + 1) # 1 extra to check if there's a further page
+    if orm:
+        rows = q.all()
+    else:
+        selected = s.execute(q)
+        keys = selected.keys()
+        N = len(keys) - len(extra_entities)
+        keys = keys[:N]
+        rows = selected.fetchall()
+    return order_cols, mapped_ocols, extra_entities, rows, keys
 
-    rows = q.all()
+def orm_get_page(q, per_page, place, backwards):
+    """Get a page from an SQLAlchemy ORM query.
 
-    page = orm_page_from_rows(
-        rows,
-        per_page,
-        order_cols,
-        mapped_ocols,
-        extra_entities,
-        result_type,
-        keys,
-        backwards,
-        current_marker=place)
+    :param q: The :class:`Query` to paginate.
+    :param per_page: Number of rows per page.
+    :param place: Keyset representing the place after which to start the page.
+    :param backwards: If ``True``, reverse pagination direction.
+    :returns: :class:`Page`
+    """
+    result_type = orm_result_type(q)
+    paging_result = perform_paging(q=q,
+                                   per_page=per_page,
+                                   place=place,
+                                   backwards=backwards,
+                                   orm=True)
+    page = orm_page_from_rows(paging_result,
+                              result_type,
+                              per_page,
+                              backwards,
+                              current_marker=place)
 
     return page
 
@@ -163,32 +162,53 @@ def core_get_page(s, selectable, per_page, place, backwards):
     :param backwards: If ``True``, reverse pagination direction.
     :returns: :class:`Page`
     """
-    order_cols = parse_clause(selectable._order_by_clause)
+    paging_result = perform_paging(q=selectable,
+                                   per_page=per_page,
+                                   place=place,
+                                   backwards=backwards,
+                                   orm=False,
+                                   s=s)
+    page = core_page_from_rows(paging_result,
+                               per_page,
+                               backwards,
+                               current_marker=place)
+    return page
 
-    if backwards:
-        order_cols = [c.reversed for c in order_cols]
-    clauses = [x.uo for x in order_cols]
 
-    selectable = selectable.order_by(None).order_by(*clauses)
+def core_page_from_rows(
+        paging_result,
+        page_size,
+        backwards=False,
+        current_marker=None):
+    """Turn a raw page of results for an SQLAlchemy Core query (as obtained by
+    :func:`.core_get_page`) into a :class:`.Page` for external consumers."""
+    ocols, mapped_ocols, extra_columns, rows, keys = paging_result
 
-    if place:
-        where = where_condition_for_page(order_cols, place)
-        selectable = selectable.where(where)
+    def clean_row(row):
+        # SA Core RowProxy objects are constructed separately for each row,
+        # rather than having a special type constructed for the query as in the
+        # ORM case.  We need to trim off the extra entities.
+        # Attributes:
+        #     _parent is a reference to parent resultproxy metadata 
+        #         (yikes, we can't really replace this cleanly... can we?)
+        #     _row is a raw list
+        #     _processors is a list correlated with _row
+        #     _keymap is a map from column keys to (processor, obj, index)
+        #         where index is an index into _row
+        N = len(row._row) - len(extra_columns)
+        row = copy(row)
+        row._row = row._row[:N]
+        row._processors = row._processors[:N]
+        row._keymap = {k: v for k, v in row._keymap.items()
+                       if v[2] < N}
+        return row
 
-    selectable = selectable.limit(per_page + 1)
-
-    selected = s.execute(selectable)
-    rowkeys = selected.keys()
-    rows = selected.fetchall()
-
-    page = core_page_from_rows(
-        rows,
-        per_page,
-        order_cols,
-        backwards,
-        current_marker=place,
-        keys=rowkeys)
-
+    out_rows = [clean_row(row) for row in rows]
+    key_rows = [tuple(col.get_from_row(row) for col in mapped_ocols)
+                for row in rows]
+    paging = Paging(out_rows, page_size, ocols, backwards,
+                    current_marker, markers=key_rows)
+    page = Page(paging.rows, paging, keys=keys)
     return page
 
 

--- a/sqlakeyset/paging.py
+++ b/sqlakeyset/paging.py
@@ -193,7 +193,10 @@ def core_page_from_rows(
     ocols, mapped_ocols, extra_columns, rows, keys = paging_result
 
     def clean_row(row):
-        """Trim off the extra columns and return as a correct RowProxy."""
+        """Trim off the extra columns and return as a correct-as-possible
+        RowProxy."""
+        if not extra_columns:
+            return row
         N = len(row._row) - len(extra_columns)
         row = row[:N]
         process_row = result_proxy._process_row

--- a/sqlakeyset/results.py
+++ b/sqlakeyset/results.py
@@ -97,37 +97,36 @@ class Paging:
             get_marker=None,
             markers=None):
 
+        self.original_rows = rows
+
         if get_marker:
-            marker = lambda i: get_marker(rows[i], ocols)
+            marker = lambda i: get_marker(self.original_rows[i], ocols)
         else:
             if rows and not markers:
                 raise ValueError
             marker = markers.__getitem__
 
-        self.original_rows = rows
-
         self.per_page = per_page
         self.backwards = backwards
 
         excess = rows[per_page:]
+        rows = rows[:per_page]
+        self.rows = rows
         self.marker_0 = current_marker
 
         if rows:
             self.marker_1 = marker(0)
-            self.marker_n = marker(min(per_page, len(rows)) - 1)
+            self.marker_n = marker(len(rows) - 1)
         else:
             self.marker_1 = None
             self.marker_n = None
 
         if excess:
-            self.marker_nplus1 = marker(per_page)
+            self.marker_nplus1 = marker(len(rows))
         else:
             self.marker_nplus1 = None
 
         four = [self.marker_0, self.marker_1, self.marker_n, self.marker_nplus1]
-
-        rows = rows[:per_page]
-        self.rows = rows
 
         if backwards:
             self.rows.reverse()

--- a/sqlakeyset/results.py
+++ b/sqlakeyset/results.py
@@ -1,3 +1,4 @@
+"""Result data structures and bookmark handling."""
 from __future__ import unicode_literals
 
 from .serial import Serial

--- a/sqlakeyset/serial/serial.py
+++ b/sqlakeyset/serial/serial.py
@@ -1,3 +1,4 @@
+"""Bookmark (de)serialization logic."""
 from __future__ import unicode_literals
 
 import decimal

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -2,9 +2,9 @@ from pytest import raises, warns, mark
 from sqlalchemy import asc, desc, Column, Integer, String, column
 from sqlalchemy.sql.expression import nullslast
 
-from sqlakeyset import OC, Paging, Page
+from sqlakeyset import Paging, Page
 from sqlakeyset import serialize_bookmark
-from sqlakeyset.columns import DerivedKey
+from sqlakeyset.columns import OC, DerivedColumn
 
 
 @mark.filterwarnings("ignore:.*NULLS FIRST.*")
@@ -36,8 +36,8 @@ def test_oc():
 
 
 def test_okeys():
-    a = DerivedKey(OC(asc('a')), lambda x:x)
-    b = DerivedKey(OC(desc('b')), lambda x:x)
+    a = DerivedColumn(OC(asc('a')), lambda x:x)
+    b = DerivedColumn(OC(desc('b')), lambda x:x)
     assert a.oc.is_ascending
     assert not b.oc.is_ascending
 

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -4,7 +4,7 @@ from sqlalchemy.sql.expression import nullslast
 from sqlalchemy.sql.operators import asc_op, desc_op
 
 from sqlakeyset import Page, Paging, serialize_bookmark
-from sqlakeyset.columns import (OC, DerivedColumn,
+from sqlakeyset.columns import (OC, AppendedColumn, DirectColumn,
                                 _get_order_direction,
                                 _remove_order_direction,
                                 _reverse_order_direction)
@@ -48,20 +48,20 @@ def test_order_manipulation():
     d = desc(base)
     assert is_asc(a)
     assert not is_asc(d)
-    for lhs, rhs in [
+    equal_pairs = [
         (scrub(a), base),
         (scrub(d), base),
         (scrub(asc(l)), scrub(a.label('test'))),
         (flip(a), d),
         (flip(d), a),
-    ]:
+    ]
+    for lhs, rhs in equal_pairs:
         assert str(lhs) == str(rhs)
 
 
-
-def test_okeys():
-    a = DerivedColumn(OC(asc('a')), lambda x:x)
-    b = DerivedColumn(OC(desc('b')), lambda x:x)
+def test_mappedocols():
+    a = AppendedColumn(OC(asc('a')))
+    b = DirectColumn(OC(desc('b')), 0)
     assert a.oc.is_ascending
     assert not b.oc.is_ascending
 

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -1,11 +1,12 @@
-from pytest import raises
-from sqlalchemy import asc, desc, Column, Integer, String
+from pytest import raises, warns, mark
+from sqlalchemy import asc, desc, Column, Integer, String, column
 from sqlalchemy.sql.expression import nullslast
 
 from sqlakeyset import OC, Paging, Page
 from sqlakeyset import serialize_bookmark
 
 
+@mark.filterwarnings("ignore:One of your order columns had a NULLS")
 def test_oc():
     a = asc('a')
     b = desc('a')
@@ -114,7 +115,8 @@ def test_paging_object2_per_page_2():
 
 
 def test_paging_object_text():
-    ob = [OC(Column('id', Integer)), OC(Column('name', String))]
+    ob = [OC(Column('id', Integer, nullable=False)),
+          OC(Column('name', String, nullable=False))]
 
     p = Paging(T3, 2, ob, backwards=False, current_marker=None, get_marker=getitem)
 
@@ -131,3 +133,8 @@ def test_paging_object_text():
     general_asserts(p)
 
     assert p.further
+
+def test_warn_on_nullslast():
+    with warns(UserWarning):
+        ob = [OC(nullslast(column('id')))]
+        p = Paging(T1, 10, ob, backwards=False, current_marker=None, get_marker=getitem)

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -4,9 +4,10 @@ from sqlalchemy.sql.expression import nullslast
 
 from sqlakeyset import OC, Paging, Page
 from sqlakeyset import serialize_bookmark
+from sqlakeyset.columns import DerivedKey
 
 
-@mark.filterwarnings("ignore:One of your order columns had a NULLS")
+@mark.filterwarnings("ignore:.*NULLS FIRST.*")
 def test_oc():
     a = asc('a')
     b = desc('a')
@@ -32,6 +33,13 @@ def test_oc():
     assert n.name == 'a'
     assert n.quoted_full_name == 'a'
     assert repr(n) == '<OC: a DESC NULLS LAST>'
+
+
+def test_okeys():
+    a = DerivedKey(OC(asc('a')), lambda x:x)
+    b = DerivedKey(OC(desc('b')), lambda x:x)
+    assert a.oc.is_ascending
+    assert not b.oc.is_ascending
 
 
 def general_asserts(p):

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -67,6 +67,8 @@ def test_mappedocols():
     b = DirectColumn(OC(desc('b')), 0)
     assert a.oc.is_ascending
     assert not b.oc.is_ascending
+    assert b.reversed.oc.is_ascending
+    assert b.reversed.oc.is_ascending
 
 
 def test_flask_sqla_compat():

--- a/tests/test_paging.py
+++ b/tests/test_paging.py
@@ -4,7 +4,7 @@ import pytest
 from sqlalchemy import select, String, Column, Integer, ForeignKey, column, table, desc, func
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import relationship, aliased, joinedload, column_property, Bundle
+from sqlalchemy.orm import relationship, aliased, column_property, Bundle
 from sqlbag import temporary_database, S
 
 from sqlakeyset import get_page, select_page, serialize_bookmark, unserialize_bookmark

--- a/tests/test_paging.py
+++ b/tests/test_paging.py
@@ -246,6 +246,9 @@ def test_orm_query2(dburl):
     with S(dburl, echo=ECHO) as s:
         q = s.query(Book).order_by(Book.id, Book.name)
         check_paging_orm(q=q)
+        q = s.query(Book).only_return_tuples(True) \
+            .order_by(Book.id, Book.name)
+        check_paging_orm(q=q)
 
 
 def test_orm_query3(dburl):


### PR DESCRIPTION
This is a bit of a big one. Started out just trying to support ordering by hybrid attributes; ended up doing a refactor and documenting a bunch of stuff.

Anyway, what's new:

- Support for ordering by essentially arbitrary expressions, including `hybrid_property`, `column_property`, SQL functions, correlated subqueries, etc.
  - The main complication here is that we now can order by keys that are not functions of the query's output rows. Since we need the values of these columns to get markers, there's some hackery involved to add them to the query, then split the result rows into the part the user is expecting and the extra bits for our markers.
- Brought the implementations of `get_page` and `select_page` closer together. SQLAlchemy Core functionality should now be at feature parity with the ORM functionality.
- Updated README to note that things go bad when ordering columns contain nulls. Also attempted to detect this possibility at runtime and raise warnings.
- Removed `process_args` and `OC` exports from the top-level module. 
- Wrote docstrings for all the public API and much of the internals.
- Set up barebones sphinx autodoc. If we copy some chunks of the README in as an intro/quickstart page, it should be pretty usable.