### PR TITLE
Update setup.py to reflect dependency on sqlalchemy 1.3.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     author='Robert Lechte',
     author_email='robertlechte@gmail.com',
     install_requires=[
-        'sqlalchemy',
+        'sqlalchemy>=1.3.11',
         'python-dateutil'
     ],
     zip_safe=False,


### PR DESCRIPTION
on `sqlakeyset==0.1.1579837191` with `SQLAlchemy==1.3.8` I was getting:
```
  File "/Users/tng/Development/virtualenvs/squarewave/lib/python3.7/site-packages/sqlakeyset/paging.py", line 22, in orm_result_type
    if query.is_single_entity:
AttributeError: 'BaseQuery' object has no attribute 'is_single_entity'
```
Looks like sqlakeyset requires sqlalchemy 1.3.11 per docs.

https://docs.sqlalchemy.org/en/13/orm/query.html#sqlalchemy.orm.query.Query.is_single_entity

This requirement should be reflected in setup.py