### PR TITLE
Better attribute introspection

### DIFF
--- a/sqlakeyset/columns.py
+++ b/sqlakeyset/columns.py
@@ -6,6 +6,7 @@ from warnings import warn
 import sqlalchemy
 from sqlalchemy import asc, column
 from sqlalchemy.orm import Bundle, Mapper, class_mapper
+from sqlalchemy.orm.attributes import QueryableAttribute
 from sqlalchemy.sql.elements import _label_reference
 from sqlalchemy.sql.expression import ClauseList, ColumnElement, Label
 from sqlalchemy.sql.operators import (asc_op, desc_op, nullsfirst_op,
@@ -324,7 +325,7 @@ def derive_order_key(ocol, desc, index):
             pass
 
     # is an attribute
-    if hasattr(expr, 'info'):
+    if isinstance(expr, QueryableAttribute):
         mapper = expr.parent
         tname = mapper.local_table.description
         if ocol.table_name == tname and ocol.name == expr.name:

--- a/tests/test_paging.py
+++ b/tests/test_paging.py
@@ -44,7 +44,7 @@ class Author(Base):
     id = Column(Integer, primary_key=True)
     name = Column(String(255), nullable=False)
     books = relationship('Book', backref='author')
-    info = Column(String(255), nullable=True)
+    info = Column(String(255), nullable=False)
 
     @hybrid_property
     def book_count(self):
@@ -111,13 +111,14 @@ def _dburl(request):
 
         if x == 1:
             b.a = None
-            b.author = Author(name='Willy Shakespeare')
+            b.author = Author(name='Willy Shakespeare',
+                              info='Old timer')
 
         data.append(b)
 
     for x in range(count):
         author = Author(name='Author {}'.format(x),
-                        info='Author {}'.format(x) + '\nHi' * (x % 3))
+                        info='Rank {}'.format(count + 1 - x))
         abooks = []
         for y in range((2*x) % 10):
             b = Book(name='Book {}-{}'.format(x, y), a=x+y, b=(y*x) % 2, c=count - x, d=99-y)
@@ -291,7 +292,7 @@ def test_orm_column_property(dburl):
 def test_column_named_info(dburl):
     # See issue djrobstep#24
     with S(dburl, echo=ECHO) as s:
-        q = s.query(Author).from_self().order_by(Author.info)
+        q = s.query(Author).from_self().order_by(Author.info, Author.id)
         check_paging_orm(q=q)
 
 

--- a/tests/test_paging.py
+++ b/tests/test_paging.py
@@ -44,6 +44,7 @@ class Author(Base):
     id = Column(Integer, primary_key=True)
     name = Column(String(255), nullable=False)
     books = relationship('Book', backref='author')
+    info = Column(String(255), nullable=True)
 
     @hybrid_property
     def book_count(self):
@@ -115,7 +116,8 @@ def _dburl(request):
         data.append(b)
 
     for x in range(count):
-        author = Author(name='Author {}'.format(x))
+        author = Author(name='Author {}'.format(x),
+                        info='Author {}'.format(x) + '\nHi' * (x % 3))
         abooks = []
         for y in range((2*x) % 10):
             b = Book(name='Book {}-{}'.format(x, y), a=x+y, b=(y*x) % 2, c=count - x, d=99-y)
@@ -283,6 +285,13 @@ def test_orm_column_property(dburl):
         q = s.query(Book).order_by(Book.popularity, Book.id)
         check_paging_orm(q=q)
         q = s.query(Book, Author).join(Book.author).order_by(Book.popularity.desc(), Book.id)
+        check_paging_orm(q=q)
+
+
+def test_column_named_info(dburl):
+    # See issue djrobstep#24
+    with S(dburl, echo=ECHO) as s:
+        q = s.query(Author).from_self().order_by(Author.info)
         check_paging_orm(q=q)
 
 


### PR DESCRIPTION
Fixes #24.

This isn't the ideal way to handle aliased/from_self queries: as things are here, the introspection will always fail and thus an AppendedColumn will always be generated, resulting in duplicate column selections:

```sql
SELECT anon_1.author_id AS anon_1_author_id, anon_1.author_name AS anon_1_author_name, anon_1.author_info AS anon_1_author_info, anon_1.author_info AS _sqlakeyset_oc_167, anon_1.author_id AS _sqlakeyset_oc_168
FROM (SELECT author.id AS author_id, author.name AS author_name, author.info AS author_info
FROM author) AS anon_1
WHERE row(%(row_1)s, %(row_2)s) > row(anon_1.author_info, anon_1.author_id) ORDER BY _sqlakeyset_oc_167 DESC, _sqlakeyset_oc_168 DESC
```

Not a huge deal, but definitely room for improvement.