### PR TITLE
Support custom types in order columns

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           key: deps1-{{ .Branch }}-{{ checksum "pyproject.toml" }}
       - run:
           name: Wait for db
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+          command: dockerize -wait tcp://localhost:5432 -wait tcp://localhost:3306 -timeout 1m
       - run: sudo apt-get update
       - run: sudo apt-get install -y postgresql-client
       - run: sudo apt-get install -y default-mysql-client

--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,9 @@ sqlakeyset: offset-free paging for sqlalchemy
 
 **Notice:** In accordance with Python 2's rapidly-approaching end-of-life date, we've stopped supporting Python 2. If you really need it, the latest version to support Python 2 is 0.1.1559103842, but you'll miss out on all the latest features and bugfixes from the latest version. You should be upgrading anyway!
 
-.. image:: https://travis-ci.org/djrobstep/sqlakeyset.svg?branch=master
-    :target: https://travis-ci.org/djrobstep/sqlakeyset
+.. image:: https://circleci.com/gh/djrobstep/sqlakeyset.svg?style=svg
+    :target: https://circleci.com/gh/djrobstep/sqlakeyset
+
 
 This library implements keyset-based paging for SQLAlchemy (both ORM and core).
 

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -25,3 +25,9 @@ In most use cases, you shouldn't need to call these directly - bookmarks can be 
 .. autofunction:: serialize_bookmark
 .. autofunction:: unserialize_bookmark
 
+Custom Types in Bookmarks
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you're using custom types for your ordering columns, you will need to register them with sqlakeyset in order to use bookmarks.
+
+.. autofunction:: custom_bookmark_type

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ flake8 = "*"
 isort = "*"
 pytz = "*"
 black = { version = ">=19.10b0", python=">=3.6" }
+sqlalchemy_utils = "*"
+arrow = "*"
+
 
 [tool.isort]
 multi_line_output = 3

--- a/sqlakeyset/__init__.py
+++ b/sqlakeyset/__init__.py
@@ -1,6 +1,11 @@
 from .paging import get_page, select_page
-from .results import (Page, Paging, custom_bookmark_type, serialize_bookmark,
-                      unserialize_bookmark)
+from .results import (
+    Page,
+    Paging,
+    custom_bookmark_type,
+    serialize_bookmark,
+    unserialize_bookmark,
+)
 
 __all__ = [
     "get_page",

--- a/sqlakeyset/__init__.py
+++ b/sqlakeyset/__init__.py
@@ -1,5 +1,6 @@
 from .paging import get_page, select_page
-from .results import serialize_bookmark, unserialize_bookmark, Page, Paging
+from .results import (Page, Paging, custom_bookmark_type, serialize_bookmark,
+                      unserialize_bookmark)
 
 __all__ = [
     "get_page",
@@ -8,4 +9,5 @@ __all__ = [
     "unserialize_bookmark",
     "Page",
     "Paging",
+    "custom_bookmark_type",
 ]

--- a/sqlakeyset/columns.py
+++ b/sqlakeyset/columns.py
@@ -103,6 +103,28 @@ class OC:
             raise ValueError  # pragma: no cover
         return OC(new_uo)
 
+    def pair_for_comparison(self, value, dialect):
+        """Return a pair of SQL expressions representing comparable values for
+        this ordering column and a specified value. 
+
+        :param value: A value to compare this column against.
+        :param dialect: The :class:`sqlalchemy.engine.interfaces.Dialect` in
+            use.
+        :returns: A pair `(a, b)` such that the comparison `a < b` is the
+            condition for the value of this OC being past `value` in the paging
+            order."""
+        compval = self.comparable_value
+        # If this OC is a column with a custom type, apply the custom
+        # preprocessing to the comparsion value:
+        try:
+            value = compval.type.process_bind_param(value, dialect)
+        except AttributeError:
+            pass
+        if self.is_ascending:
+            return compval, value
+        else:
+            return value, compval
+
     def __str__(self):
         return str(self.uo)
 

--- a/sqlakeyset/columns.py
+++ b/sqlakeyset/columns.py
@@ -105,7 +105,7 @@ class OC:
 
     def pair_for_comparison(self, value, dialect):
         """Return a pair of SQL expressions representing comparable values for
-        this ordering column and a specified value. 
+        this ordering column and a specified value.
 
         :param value: A value to compare this column against.
         :param dialect: The :class:`sqlalchemy.engine.interfaces.Dialect` in

--- a/sqlakeyset/paging.py
+++ b/sqlakeyset/paging.py
@@ -36,7 +36,7 @@ def where_condition_for_page(ordering_columns, place, dialect):
         ``.filter()``.
     """
     if len(ordering_columns) != len(place):
-        raise ValueError('bad paging value') # pragma: no cover
+        raise ValueError("bad paging value")  # pragma: no cover
 
     zipped = zip(ordering_columns, place)
     swapped = [c.pair_for_comparison(value, dialect) for c, value in zipped]

--- a/sqlakeyset/results.py
+++ b/sqlakeyset/results.py
@@ -16,16 +16,19 @@ SERIALIZER_SETTINGS = dict(
 s = Serial(**SERIALIZER_SETTINGS)
 
 
-def custom_bookmark_type(type, code, serializer, unserializer):
+def custom_bookmark_type(type, code, deserializer=None, serializer=None):
     """Register (de)serializers for bookmarks to use for a custom type.
 
     :param type: Python type to register.
     :paramtype type: type
     :param code: A short alphabetic code to use to identify this type in serialized bookmarks.
     :paramtype code: str
-    :param serializer: A function mapping `type` values to strings.
-    :param unserializer: Inverse for `serializer`."""
-    s.register_type(type, code, serializer, unserializer)
+    :param serializer: A function mapping `type` values to strings. Default is
+        `str`.
+    :param deserializer: Inverse for `serializer`. Default is the `type`
+        constructor."""
+    s.register_type(type, code,
+                    deserializer=deserializer, serializer=serializer)
 
 
 def serialize_bookmark(marker):

--- a/sqlakeyset/results.py
+++ b/sqlakeyset/results.py
@@ -27,8 +27,7 @@ def custom_bookmark_type(type, code, deserializer=None, serializer=None):
         `str`.
     :param deserializer: Inverse for `serializer`. Default is the `type`
         constructor."""
-    s.register_type(type, code,
-                    deserializer=deserializer, serializer=serializer)
+    s.register_type(type, code, deserializer=deserializer, serializer=serializer)
 
 
 def serialize_bookmark(marker):

--- a/sqlakeyset/results.py
+++ b/sqlakeyset/results.py
@@ -16,6 +16,18 @@ SERIALIZER_SETTINGS = dict(
 s = Serial(**SERIALIZER_SETTINGS)
 
 
+def custom_bookmark_type(type, code, serializer, unserializer):
+    """Register (de)serializers for bookmarks to use for a custom type.
+
+    :param type: Python type to register.
+    :paramtype type: type
+    :param code: A short alphabetic code to use to identify this type in serialized bookmarks.
+    :paramtype code: str
+    :param serializer: A function mapping `type` values to strings.
+    :param unserializer: Inverse for `serializer`."""
+    s.register_type(type, code, serializer, unserializer)
+
+
 def serialize_bookmark(marker):
     """Serialize a place marker to a bookmark string.
 

--- a/sqlakeyset/serial/serial.py
+++ b/sqlakeyset/serial/serial.py
@@ -30,6 +30,11 @@ class Serial(object):
         self.custom_serializations = {}
         self.custom_unserializations = {}
 
+    def register_type(self, type, code,
+                      serializer, unserializer):
+        self.custom_serializations[type] = lambda x: (code, serializer(x))
+        self.custom_unserializations[code] = unserializer
+
     def split(self, joined):
         s = sio(joined)
         r = csvreader(s, **self.kwargs)

--- a/sqlakeyset/serial/serial.py
+++ b/sqlakeyset/serial/serial.py
@@ -22,28 +22,38 @@ DATETIME = "dt"
 TIME = "t"
 UUID = "uuid"
 
-parsedate = lambda x: dateutil.parser.parse(x).date()
-binencode = lambda x: base64.b64encode(x).decode('utf-8')
-bindecode = lambda x: base64.b64decode(x.encode('utf-8'))
+
+def parsedate(x):
+    return dateutil.parser.parse(x).date()
+
+
+def binencode(x):
+    return base64.b64encode(x).decode("utf-8")
+
+
+def bindecode(x):
+    return base64.b64decode(x.encode("utf-8"))
+
 
 TYPES = [
-    (str, 's'),
-    (int, 'i'),
-    (float, 'f'),
-    (bytes, 'b', bindecode, binencode),
-    (decimal.Decimal, 'n'),
-    (uuid.UUID, 'uuid'),
-    (datetime.datetime, 'dt', dateutil.parser.parse),
-    (datetime.date, 'd', parsedate),
-    (datetime.time, 't'),
+    (str, "s"),
+    (int, "i"),
+    (float, "f"),
+    (bytes, "b", bindecode, binencode),
+    (decimal.Decimal, "n"),
+    (uuid.UUID, "uuid"),
+    (datetime.datetime, "dt", dateutil.parser.parse),
+    (datetime.date, "d", parsedate),
+    (datetime.time, "t"),
 ]
 
 BUILTINS = {
-    'x': None,
-    'true': True,
-    'false': False,
+    "x": None,
+    "true": True,
+    "false": False,
 }
 BUILTINS_INV = {v: k for k, v in BUILTINS.items()}
+
 
 class Serial(object):
     def __init__(self, *args, **kwargs):
@@ -53,8 +63,7 @@ class Serial(object):
         for definition in TYPES:
             self.register_type(*definition)
 
-    def register_type(self, type, code,
-                      deserializer=None, serializer=None):
+    def register_type(self, type, code, deserializer=None, serializer=None):
         if serializer is None:
             serializer = str
         if deserializer is None:
@@ -92,7 +101,7 @@ class Serial(object):
     def serialize_value(self, x):
         try:
             c, x = self.custom_serializations[type(x)](x)
-            return '{}:{}'.format(c, x)
+            return "{}:{}".format(c, x)
         except KeyError:
             pass
 
@@ -118,4 +127,4 @@ class Serial(object):
         try:
             return BUILTINS[c]
         except KeyError:
-            raise ValueError('unrecognized value {}'.format(x))
+            raise ValueError("unrecognized value {}".format(x))

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -49,6 +49,7 @@ def test_oc():
 def test_order_manipulation():
     def is_asc(c):
         return _get_order_direction(c) == asc_op
+
     flip = _reverse_order_direction
     scrub = _remove_order_direction
     base = column("a")

--- a/tests/test_paging.py
+++ b/tests/test_paging.py
@@ -22,7 +22,13 @@ import arrow
 from sqlalchemy_utils import ArrowType
 from datetime import timedelta
 
-from sqlakeyset import get_page, select_page, serialize_bookmark, unserialize_bookmark, custom_bookmark_type
+from sqlakeyset import (
+    get_page,
+    select_page,
+    serialize_bookmark,
+    unserialize_bookmark,
+    custom_bookmark_type,
+)
 from sqlakeyset.paging import process_args
 from sqlakeyset.columns import OC
 
@@ -34,10 +40,12 @@ ECHO = False
 
 BOOK = "t_Book"
 
-custom_bookmark_type(arrow.Arrow, 'da', deserializer=arrow.get)
+custom_bookmark_type(arrow.Arrow, "da", deserializer=arrow.get)
+
 
 def randtime():
     return arrow.now() - timedelta(seconds=randrange(86400))
+
 
 class Book(Base):
     __tablename__ = BOOK
@@ -162,7 +170,7 @@ def _dburl(request):
             abooks.append(b)
             data.append(b)
 
-    with temporary_database(request.param, host='localhost') as dburl:
+    with temporary_database(request.param, host="localhost") as dburl:
         with S(dburl) as s:
             Base.metadata.create_all(s.connection())
             s.add_all(data)
@@ -175,7 +183,7 @@ pg_only_dburl = pytest.fixture(params=["postgresql"])(_dburl)
 
 @pytest.fixture(params=["postgresql", "mysql"])
 def joined_inheritance_dburl(request):
-    with temporary_database(request.param, host='localhost') as dburl:
+    with temporary_database(request.param, host="localhost") as dburl:
         with S(dburl) as s:
             JoinedInheritanceBase.metadata.create_all(s.connection())
             s.add_all(

--- a/tests/test_paging.py
+++ b/tests/test_paging.py
@@ -34,7 +34,7 @@ ECHO = False
 
 BOOK = "t_Book"
 
-custom_bookmark_type(arrow.Arrow, 'da', str, arrow.get)
+custom_bookmark_type(arrow.Arrow, 'da', deserializer=arrow.get)
 
 def randtime():
     return arrow.now() - timedelta(seconds=randrange(86400))
@@ -50,7 +50,7 @@ class Book(Base):
     author_id = Column(Integer, ForeignKey("author.id"))
     prequel_id = Column(Integer, ForeignKey(id), nullable=True)
     prequel = relationship("Book", remote_side=[id], backref="sequel", uselist=False)
-    published_at = Column(ArrowType, default=randtime)
+    published_at = Column(ArrowType, default=randtime, nullable=False)
 
     popularity = column_property(b + c * d)
 

--- a/tests/test_ser.py
+++ b/tests/test_ser.py
@@ -42,12 +42,15 @@ s.custom_unserializations["z"] = unser_z
 class Y(str):
     pass
 
-rev = lambda x: x[::-1]
 
-s.register_type(Y, 'y', rev, rev)
+def reversestr(x):
+    return x[::-1]
 
 
-with io.open('tests/blns.txt') as f:
+s.register_type(Y, "y", reversestr, reversestr)
+
+
+with io.open("tests/blns.txt") as f:
     NAUGHTY = f.read().splitlines()
 
 

--- a/tests/test_ser.py
+++ b/tests/test_ser.py
@@ -39,7 +39,15 @@ s.custom_serializations[Z] = ser_z
 s.custom_unserializations["z"] = unser_z
 
 
-with io.open("tests/blns.txt") as f:
+class Y(str):
+    pass
+
+rev = lambda x: x[::-1]
+
+s.register_type(Y, 'y', rev, rev)
+
+
+with io.open('tests/blns.txt') as f:
     NAUGHTY = f.read().splitlines()
 
 
@@ -66,14 +74,16 @@ def test_serial():
     assert s.serialize_value("abc") == "s:abc"
     assert s.serialize_value(b"abc") == "b:YWJj"
     assert s.serialize_value(b"abc") == "b:YWJj"
+    assert s.serialize_value(Z("abc")) == "z:cba"
+    assert s.serialize_value(Y("abc")) == "y:cba"
     assert s.serialize_value(datetime.date(2007, 12, 5)) == "d:2007-12-05"
-    dt = s.serialize_value(datetime.datetime(2007, 12, 5, 12, 30, 30, tzinfo=utc))
 
+    dt = s.serialize_value(datetime.datetime(2007, 12, 5, 12, 30, 30, tzinfo=utc))
     assert dt == "dt:2007-12-05 12:30:30+00:00"
 
     assert s.serialize_value(datetime.time(12, 34, 56)) == "t:12:34:56"
-    _uuid = s.serialize_value(uuid.UUID("939d4cc9-830d-4cca-bd74-3ec3d541a9b3"))
 
+    _uuid = s.serialize_value(uuid.UUID("939d4cc9-830d-4cca-bd74-3ec3d541a9b3"))
     assert _uuid == "uuid:939d4cc9-830d-4cca-bd74-3ec3d541a9b3"
 
     with raises(NotImplementedError):
@@ -96,6 +106,7 @@ def test_unserial():
     twoway(datetime.date(2007, 12, 5))
     twoway(datetime.datetime(2007, 12, 5, 12, 30, 30, tzinfo=utc))
     twoway(Z("abc"))
+    twoway(Y("abc"))
     twoway(uuid.UUID("939d4cc9-830d-4cca-bd74-3ec3d541a9b3"))
 
     with raises(ValueError):


### PR DESCRIPTION
Fixes #6 by:

- Providing an API to register bookmark (de)serializers for custom types.
- Ensuring bookmark values corresponding to columns with custom SQLAlchemy types are passed through the corresponding `process_bind_param` function.