### PR TITLE
Fix selected hybrid_properties

### DIFF
--- a/tests/test_paging.py
+++ b/tests/test_paging.py
@@ -279,6 +279,8 @@ def test_orm_hybrid_property(dburl):
         check_paging_orm(q=q)
         q = s.query(Book, Author).join(Book.author).order_by(Book.score, Book.id)
         check_paging_orm(q=q)
+        q = s.query(Book.score, Book, Author).join(Book.author).order_by(Book.score, Book.id)
+        check_paging_orm(q=q)
 
 
 def test_orm_column_property(dburl):


### PR DESCRIPTION
Despite claiming to be instances of QueryableAttribute, hybrid_property attributes don't actually implement the .parent property, so our code had an unhandled error when queries included hybrid props as selected columns.  With this patch, we now guard against this AttributeError and fall back to an AppendedColumn in that case.