### PR TITLE
CI pipeline to build docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,30 @@ jobs:
             poetry build
             poetry publish --username $PYPI_USERNAME --password $PYPI_PASSWORD
 
+  docs:
+    working_directory: ~/circleci
+    docker:
+      - image: circleci/python:3.8.2
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "16:c5:65:5d:31:50:a7:06:16:c2:ca:a6:3a:a9:70:be"
+      - checkout
+      - restore_cache:
+          key: deps1-{{ .Branch }}-{{ checksum "pyproject.toml" }}
+      - run:
+          name: Install sphinx
+          command: sudo pip3 install sphinx sphinx_rtd_theme
+      - run:
+          name: Build gh-pages branch
+          command: |
+            git config user.email "circleci@circleci.com"
+            git config user.name "circleci"
+            bash deploy/gh-pages.sh
+      - run:
+          name: Push gh-pages to github
+          command: git push origin gh-pages
+
 
 workflows:
   version: 2
@@ -94,6 +118,10 @@ workflows:
       - publish:
           requires:
             - build
+          filters:
+            branches:
+              only: master
+      - docs:
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
             bash deploy/gh-pages.sh
       - run:
           name: Push gh-pages to github
-          command: git push origin gh-pages
+          command: git push --force origin gh-pages
 
 
 workflows:

--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,13 @@ lint:
 	flake8 sqlakeyset
 	flake8 tests
 
+docs:
+	$(MAKE) -C doc html
+
 tidy: clean fmt lint
 
 
-all: pipupgrade clean lint tox
+all: pipupgrade clean lint tox docs
 
 publish:
 	python setup.py sdist bdist_wheel --universal

--- a/deploy/gh-pages.sh
+++ b/deploy/gh-pages.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+current=$(git rev-parse --abbrev-ref HEAD)
+tag=$(git describe --always)
+staging=$(mktemp -d)
+
+make docs
+mv doc/build/html/* $staging/
+
+git branch -D gh-pages || true
+
+# git-checkout manpage recommends this for creating an empty commit:
+git checkout --orphan gh-pages
+git rm -rf .
+# remove any ignored files:
+rm -rf *
+mv $staging/* .
+git add -f *
+git commit -m "gh-pages build for $tag"
+git checkout $current


### PR DESCRIPTION
This adds a workflow to circleCI triggered off the master branch which:

- Builds the sphinx documentation to HTML
- Pushes the built documentation to an orphan branch `gh-pages`. (at the moment using a "User key" I generated via the circleCI config that grants it my permissions - feel free to change this)

Hopefully you should be able to click a few buttons in github settings for this repo (or your account?) and we'll have auto-updated docs somewhere under github.io. :)