### PR TITLE
Use None as default page parameter

### DIFF
--- a/sqlakeyset/paging.py
+++ b/sqlakeyset/paging.py
@@ -212,14 +212,14 @@ def core_page_from_rows(
     return page
 
 
-def process_args(after=False, before=False, page=False):
+def process_args(after=False, before=False, page=None):
     if isinstance(page, str):
         page = unserialize_bookmark(page)
 
     if before is not False and after is not False:
         raise ValueError("after *OR* before")
 
-    if (before is not False or after is not False) and page is not False:
+    if (before is not False or after is not False) and page is not None:
         raise ValueError("specify either a page tuple, or before/after")
 
     if page:
@@ -238,7 +238,7 @@ def process_args(after=False, before=False, page=False):
 
 
 def select_page(
-    s, selectable, per_page=PER_PAGE_DEFAULT, after=False, before=False, page=False
+    s, selectable, per_page=PER_PAGE_DEFAULT, after=False, before=False, page=None
 ):
     """Get a page of results from a SQLAlchemy Core selectable.
 
@@ -265,7 +265,7 @@ def select_page(
     return core_get_page(s, selectable, per_page, place, backwards)
 
 
-def get_page(query, per_page=PER_PAGE_DEFAULT, after=False, before=False, page=False):
+def get_page(query, per_page=PER_PAGE_DEFAULT, after=False, before=False, page=None):
     """Get a page of results for an ORM query.
 
     Specify no more than one of the arguments ``page``, ``after`` or

--- a/tests/test_paging.py
+++ b/tests/test_paging.py
@@ -542,7 +542,7 @@ def test_args():
         process_args(before=(1, 2), page=(1, 2))
     with pytest.raises(ValueError):
         process_args(after=(1, 2), page=(1, 2))
-    assert process_args(False, False, False) == (None, False)
+    assert process_args(False, False, None) == (None, False)
 
 
 def test_bookmarks():


### PR DESCRIPTION
Since I often use type hint from IDE, I find the `False` may cause people think the parameter is boolean.   And also the program only check does the page parameter is `str` or not.

So I change default value to None.


Before update:
<img width="354" alt="Screen Shot 2020-09-04 at 4 44 38 PM" src="https://user-images.githubusercontent.com/9199638/92220098-0acb7100-eece-11ea-90b4-e73c06fa730b.png">

After update:
![Screen Shot 2020-09-04 at 4 42 12 PM](https://user-images.githubusercontent.com/9199638/92220113-1028bb80-eece-11ea-9ddf-07196fd96324.png)