### PR TITLE
Fixing dialect retrieval in `perform_paging`

### DIFF
--- a/sqlakeyset/paging.py
+++ b/sqlakeyset/paging.py
@@ -109,7 +109,8 @@ def perform_paging(q, per_page, place, backwards, orm=True, s=None):
                 q.append_column(e)
 
     if place:
-        condition = where_condition_for_page(order_cols, place, s.bind.dialect)
+        dialect = getattr(s, "bind", s).dialect
+        condition = where_condition_for_page(order_cols, place, dialect)
         # For aggregate queries, paging condition is applied *after*
         # aggregation. In SQL this means we need to use HAVING instead of
         # WHERE.

--- a/tests/test_paging.py
+++ b/tests/test_paging.py
@@ -502,6 +502,10 @@ def test_core(dburl):
     with S(dburl, echo=ECHO) as s:
         check_paging_core(selectable=selectable, s=s)
 
+    # Check again with a connection instead of session (see #37):
+    with S(dburl, echo=ECHO) as s:
+        check_paging_core(selectable=selectable, s=s.connection())
+
 
 def test_core2(dburl):
     with S(dburl, echo=ECHO) as s:


### PR DESCRIPTION
## Problem

Attribute error raised when using `sqlakeyset.paging.select_page` (from `sqlalchemy.paging.perform_paging`), which says `sqlalchemy.engine.Connection` does not have a `bind` attribute.

## Details

The function `sqlalchemy.paging.perform_paging` accepts a parameter `s` which is expected (according to the callers' docstrings) to be either `sqlalchemy.engine.Connection` or `sqlalchemy.orm.session.Session`. The dialect is accessed through `s.bind.dialect`. While `sqlalchemy.orm.session.Session` does have a `bind` attribute to access the engine, `sqlalchemy.engine.Connection` does not. As the dialect can be accessed directly by `Connection.dialect`, so the error occurs when a `sqlalchemy.engine.Connection` object is passed.

## Solution

This PR fixes this by simply adding a line that gets the dialect for either object. If `s` is `sqlalchemy.orm.session.Session`, it's equivalent to the original `s.bind.dialect`, otherwise it resolves to `s.dialect`.

Please kindly review, thanks!
