### PR TITLE
Closes #44 Add support for creating a marker and bookmark per item.

### DIFF
--- a/sqlakeyset/results.py
+++ b/sqlakeyset/results.py
@@ -247,11 +247,41 @@ class Paging:
         """Get the bookmark for item at the given row index."""
         return serialize_bookmark(self.get_marker_at(i))
 
-    def __getattr__(self, name):
-        PREFIX = "bookmark_"
-        if name.startswith(PREFIX):
-            _, attname = name.split(PREFIX, 1)
-            x = getattr(self, attname)
-            return serialize_bookmark(x)
 
-        raise AttributeError
+    # The remaining properties are just convenient shorthands to avoid manually
+    # calling serialize_bookmark.
+    @property
+    def bookmark_next(self):
+        """Bookmark for the next page (in the original query order)."""
+        return serialize_bookmark(self.next)
+
+    @property
+    def bookmark_previous(self):
+        """Bookmark for the previous page (in the original query order)."""
+        return serialize_bookmark(self.previous)
+
+    @property
+    def bookmark_current_forwards(self):
+        """Bookmark for the current page in forwards direction."""
+        return serialize_bookmark(self.current_forwards)
+
+    @property
+    def bookmark_current_backwards(self):
+        """Bookmark for the current page in backwards direction."""
+        return serialize_bookmark(self.current_backwards)
+
+    @property
+    def bookmark_current(self):
+        """Bookmark for the current page in the current paging direction."""
+        return serialize_bookmark(self.current)
+
+    @property
+    def bookmark_current_opposite(self):
+        """Bookmark for the current page in the opposite of the current
+        paging direction."""
+        return serialize_bookmark(self.current_opposite)
+
+    @property
+    def bookmark_further(self):
+        """Bookmark for the following page in the current paging direction."""
+        return serialize_bookmark(self.further)

--- a/sqlakeyset/results.py
+++ b/sqlakeyset/results.py
@@ -247,6 +247,17 @@ class Paging:
         """Get the bookmark for item at the given row index."""
         return serialize_bookmark(self.get_marker_at(i))
 
+    def items(self):
+        """Iterates over the items in the page, returning a tuple ``(marker,
+        item)`` for each."""
+        for i, row in enumerate(self.rows):
+            yield self.get_marker_at(i), row
+
+    def bookmark_items(self):
+        """Iterates over the items in the page, returning a tuple ``(bookmark,
+        item)`` for each."""
+        for i, row in enumerate(self.rows):
+            yield self.get_bookmark_at(i), row
 
     # The remaining properties are just convenient shorthands to avoid manually
     # calling serialize_bookmark.

--- a/sqlakeyset/results.py
+++ b/sqlakeyset/results.py
@@ -132,6 +132,7 @@ class Paging:
 
         self.per_page = per_page
         self.backwards = backwards
+        self._get_marker = marker
 
         excess = rows[per_page:]
         rows = rows[:per_page]
@@ -229,6 +230,14 @@ class Paging:
         """Boolean flagging whether this page contains as many rows as were
         requested in ``per_page``."""
         return len(self.rows) == self.per_page
+
+    def get_marker_at(self, i):
+        """Get the marker for item at the given row index."""
+        return self._get_marker(i), self.backwards
+
+    def get_bookmark_at(self, i):
+        """Get the bookmark for item at the given row index."""
+        return serialize_bookmark(self.get_marker_at(i))
 
     def __getattr__(self, name):
         PREFIX = "bookmark_"

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -134,7 +134,7 @@ def test_paging_objects1():
 
     ob = [OC(x) for x in ["id", "b"]]
 
-    p = Paging(T1, 10, ob, backwards=False, current_marker=None, get_marker=getitem)
+    p = Paging(T1, 10, ob, backwards=False, current_marker=None, get_keys_from=getitem)
     assert p.next == (None, False)
     assert p.further == (None, False)
     assert p.previous == (None, True)
@@ -145,7 +145,7 @@ def test_paging_objects1():
 def test_paging_object2_per_page_3():
     ob = [OC(x) for x in ["id", "b"]]
 
-    p = Paging(T2, 3, ob, backwards=False, current_marker=None, get_marker=getitem)
+    p = Paging(T2, 3, ob, backwards=False, current_marker=None, get_keys_from=getitem)
     assert p.next == ((3, 3), False)
     assert not p.has_next
     assert not p.has_previous
@@ -158,7 +158,7 @@ def test_paging_object2_per_page_3():
 def test_paging_object2_per_page_2():
     ob = [OC(x) for x in ["id", "b"]]
 
-    p = Paging(T2, 2, ob, backwards=False, current_marker=None, get_marker=getitem)
+    p = Paging(T2, 2, ob, backwards=False, current_marker=None, get_keys_from=getitem)
     assert p.next == ((2, 1), False)
     assert p.has_next
     general_asserts(p)
@@ -176,7 +176,7 @@ def test_paging_object_text():
         OC(Column("name", String, nullable=False)),
     ]
 
-    p = Paging(T3, 2, ob, backwards=False, current_marker=None, get_marker=getitem)
+    p = Paging(T3, 2, ob, backwards=False, current_marker=None, get_keys_from=getitem)
 
     assert p.rows
 
@@ -196,4 +196,4 @@ def test_paging_object_text():
 def test_warn_on_nullslast():
     with warns(UserWarning):
         ob = [OC(nullslast(column("id")))]
-        Paging(T1, 10, ob, backwards=False, current_marker=None, get_marker=getitem)
+        Paging(T1, 10, ob, backwards=False, current_marker=None, get_keys_from=getitem)

--- a/tests/test_paging.py
+++ b/tests/test_paging.py
@@ -767,9 +767,21 @@ def test_marker_and_bookmark_per_item(dburl):
         assert paging.get_marker_at(1) == ((2,), False)
         assert paging.get_marker_at(2) == ((3,), False)
 
+        paging_items = list(paging.items())
+        assert len(paging_items) == 3
+        for i, (key, book) in enumerate(paging_items):
+            assert key == ((i + 1,), False)
+            assert book.id == i + 1
+
         assert paging.get_bookmark_at(0) == ">i:1"
         assert paging.get_bookmark_at(1) == ">i:2"
         assert paging.get_bookmark_at(2) == ">i:3"
+
+        bookmark_items = list(paging.bookmark_items())
+        assert len(bookmark_items) == 3
+        for i, (key, book) in enumerate(bookmark_items):
+            assert key == ">i:%d" % (i + 1)
+            assert book.id == i + 1
 
         place, _ = paging.get_marker_at(2)
         page = get_page(q, per_page=3, before=place)


### PR DESCRIPTION
This will allow for support of the [GraphQL Relay Connection specification](https://relay.dev/graphql/connections.htm) which requires a "cursor", or keyset, per item.

In my GraphQL project, I'm doing something along the lines of:
```python
return [
    Edge(node=item, cursor=page.paging.get_bookmark_at(idx))
    for idx, item in enumerate(page)
]
```

Since this will probably be the most common usage of needing a bookmark per item, it may not be a bad idea to also include a custom iterator that yields `(marker, item)` pairs and another iterator for `(bookmark, item)` pairs, but I'll leave that up to you.

Thanks for this project! It's significantly nicer than the current LIMIT, OFFSET I'm doing and is nearly everything I needed for the Connection specification :rocket: