### PR TITLE
Improve support for custom types and enums

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: deps1-{{ .Branch }}-{{ checksum "pyproject.toml" }}
+          key: deps2-{{ .Branch }}-{{ checksum "pyproject.toml" }}
       - run: sudo apt-get update
       - run: sudo apt-get install -y postgresql-client
       - run: sudo apt-get install -y default-mysql-client
@@ -44,7 +44,7 @@ jobs:
 
             poetry install
       - save_cache:
-          key: deps1-{{ .Branch }}-{{ checksum "pyproject.toml" }}
+          key: deps2-{{ .Branch }}-{{ checksum "pyproject.toml" }}
           paths:
             - "~/.venv"
       - run:
@@ -62,7 +62,8 @@ jobs:
           name: Test with SQLAlchemy 1.4 beta
           command: |
             . ~/.venv/bin/activate
-            pip install sqlalchemy~=1.4b
+            # sqla14-compatible sqlbag isn't on PyPI yet
+            pip install --upgrade sqlalchemy~=1.4b "git+https://github.com/djrobstep/sqlbag.git@f4759318710ef33dc041710a6ff38f03d3c39b56"
             make test
       - store_test_results:
           path: test-reports
@@ -75,7 +76,7 @@ jobs:
       - setup_remote_docker
       - checkout
       - restore_cache:
-          key: deps1-{{ .Branch }}-{{ checksum "pyproject.toml" }}
+          key: deps2-{{ .Branch }}-{{ checksum "pyproject.toml" }}
       - run:
           name: Install poetry, deps
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,8 +53,16 @@ jobs:
             . ~/.venv/bin/activate
             make lint
       - run:
+          name: Test with SQLAlchemy 1.3
           command: |
             . ~/.venv/bin/activate
+            pip install sqlalchemy~=1.3
+            make test
+      - run:
+          name: Test with SQLAlchemy 1.4 beta
+          command: |
+            . ~/.venv/bin/activate
+            pip install sqlalchemy~=1.4b
             make test
       - store_test_results:
           path: test-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,14 +56,14 @@ jobs:
           name: Test with SQLAlchemy 1.3
           command: |
             . ~/.venv/bin/activate
-            pip install sqlalchemy~=1.3
+            pip install 'sqlalchemy>=1.3,<1.4'
             make test
       - run:
-          name: Test with SQLAlchemy 1.4 beta
+          name: Test with SQLAlchemy 1.4
           command: |
             . ~/.venv/bin/activate
             # sqla14-compatible sqlbag isn't on PyPI yet
-            pip install --upgrade sqlalchemy~=1.4b "git+https://github.com/djrobstep/sqlbag.git@f4759318710ef33dc041710a6ff38f03d3c39b56"
+            pip install --upgrade sqlalchemy~=1.4 "git+https://github.com/djrobstep/sqlbag.git@f4759318710ef33dc041710a6ff38f03d3c39b56"
             make test
       - store_test_results:
           path: test-reports

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # test commands and arguments
 tcommand = PYTHONPATH=. py.test -x
 tmessy = -svv
-targs = --cov-report term-missing --cov sqlakeyset --junitxml=test-reports/pytest.xml
+targs = --cov-report term-missing --cov sqlakeyset --junitxml=test-reports/pytest-`date +%s`.xml
 
 pip:
 	pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ python-dateutil = "*"
 packaging = ">=20.0"
 
 [tool.poetry.dev-dependencies]
-sqlbag = "*"
+sqlbag = "git+https://github.com/djrobstep/sqlbag.git@f4759318710ef33dc041710a6ff38f03d3c39b56"
 pytest = "*"
 pytest-cov = "*"
 pytest-clarity = ">=0.3.0-alpha.0"

--- a/sqlakeyset/columns.py
+++ b/sqlakeyset/columns.py
@@ -133,8 +133,8 @@ class OC:
         # If this OC is a column with a custom type, apply the custom
         # preprocessing to the comparsion value:
         try:
-            value = compval.type.process_bind_param(value, dialect)
-        except AttributeError:
+            value = compval.type.bind_processor(dialect)(value)
+        except (TypeError, AttributeError):
             pass
         if self.is_ascending:
             return compval, value

--- a/sqlakeyset/sqla13.py
+++ b/sqlakeyset/sqla13.py
@@ -46,7 +46,7 @@ def core_coerce_row(row, extra_columns, result_type):
     if not extra_columns:
         return row
     N = len(row._row) - len(extra_columns)
-    return result_type(row[:N])
+    return result_type(row._row[:N])
 
 
 def orm_query_keys(query):

--- a/sqlakeyset/sqla14.py
+++ b/sqlakeyset/sqla14.py
@@ -1,4 +1,5 @@
 """Methods for messing with the internals of SQLAlchemy >1.3 results."""
+from sqlalchemy.engine.result import ScalarResult
 
 
 def orm_query_keys(query):
@@ -9,15 +10,17 @@ def orm_query_keys(query):
 
 def orm_result_type(query):
     """Return the type constructor for rows that would be returned by a given
-    query; or the identity function for queries that return a single entity.
+    query; or the identity function for queries that return a single entity
+    rather than rows.
 
     :param query: The query to inspect.
     :type query: :class:`sqlalchemy.orm.query.Query`.
     :returns: either a named tuple type or the identity."""
 
-    if query.is_single_entity:
+    _iter = query._iter()
+    if isinstance(_iter, ScalarResult):
         return lambda x: x[0]
-    return query._iter()._row_getter
+    return _iter._row_getter
 
 
 def orm_coerce_row(row, extra_columns, result_type):

--- a/tests/test_paging.py
+++ b/tests/test_paging.py
@@ -244,7 +244,8 @@ def _dburl(request):
             s.add_all(data)
         yield dburl
 
-SUPPORTED_ENGINES=["sqlite", "postgresql", "mysql"]
+
+SUPPORTED_ENGINES = ["sqlite", "postgresql", "mysql"]
 
 dburl = pytest.fixture(params=SUPPORTED_ENGINES)(_dburl)
 pg_only_dburl = pytest.fixture(params=["postgresql"])(_dburl)
@@ -633,7 +634,7 @@ def test_core_enum(dburl):
 
 def test_core_order_by_enum(dburl):
     with S(dburl, echo=ECHO) as s:
-        selectable = select([Light.id, Light.colour]).order_by(
+        selectable = select([Light.id]).order_by(
             Light.colour, Light.intensity, Light.id
         )
         check_paging_core(selectable=selectable, s=s)
@@ -647,8 +648,32 @@ def test_core_result_processor(dburl):
 
 def test_core_order_by_result_processor(dburl):
     with S(dburl, echo=ECHO) as s:
-        selectable = select([Light.id, Light.myint]).order_by(Light.myint, Light.id)
+        selectable = select([Light.id]).order_by(Light.myint, Light.id)
         check_paging_core(selectable=selectable, s=s)
+
+
+def test_orm_enum(dburl):
+    with S(dburl, echo=ECHO) as s:
+        q = s.query(Light.id, Light.colour).order_by(Light.intensity, Light.id)
+        check_paging_orm(q=q)
+
+
+def test_orm_order_by_enum(dburl):
+    with S(dburl, echo=ECHO) as s:
+        q = s.query(Light.id).order_by(Light.colour, Light.intensity, Light.id)
+        check_paging_orm(q=q)
+
+
+def test_orm_result_processor(dburl):
+    with S(dburl, echo=ECHO) as s:
+        q = s.query(Light.id, Light.myint).order_by(Light.intensity, Light.id)
+        check_paging_orm(q=q)
+
+
+def test_orm_order_by_result_processor(dburl):
+    with S(dburl, echo=ECHO) as s:
+        q = s.query(Light.id).order_by(Light.myint, Light.id)
+        check_paging_orm(q=q)
 
 
 def test_args():


### PR DESCRIPTION
This PR fixes two issues that were causing problems with some custom types:

- Result processors were running twice, leading to incorrect results for non-idempotent processors.
- Bind param processing was only running for types that used the `process_bind_param` helper, which left out e.g. sqlalchemy's built-in `Enum` type. This has been amended to use the `bind_processor` directly.

Closes #47.
