### PR TITLE
Support multiple Engines

### DIFF
--- a/sqlakeyset/paging.py
+++ b/sqlakeyset/paging.py
@@ -83,7 +83,7 @@ def perform_paging(q, per_page, place, backwards, orm=True, s=None):
         column_descriptions = q._raw_columns
     try:
         # for sessions, dialect is available via the bind:
-        dialect = s.get_bind().dialect
+        dialect = s.get_bind(clause=getattr(q, 'statement', q)).dialect
     except Exception:
         # connections have a direct .dialect
         dialect = s.dialect

--- a/tests/test_paging.py
+++ b/tests/test_paging.py
@@ -5,6 +5,7 @@ from packaging import version
 
 import pytest
 import sqlalchemy
+from sqlalchemy.orm import sessionmaker
 from sqlalchemy import (
     select,
     String,
@@ -731,3 +732,23 @@ def test_orm_custom_session_bind(dburl):
 
         q = s.query(Book, Author, Book.id).outerjoin(Author).order_by(*spec)
         check_paging_orm(q=q)
+
+
+def test_multiple_engines(dburl, joined_inheritance_dburl):
+
+    eng = sqlalchemy.create_engine(dburl)
+    eng2 = sqlalchemy.create_engine(joined_inheritance_dburl)
+    session_factory = sessionmaker()
+    Base.metadata.bind = eng
+    JoinedInheritanceBase.metadata.bind = eng2
+
+    s = session_factory()
+
+    spec = [desc(Book.b), Book.d, Book.id]
+    q = s.query(Book, Author, Book.id).outerjoin(Author).order_by(*spec)
+
+    check_paging_orm(q=q)
+
+    s.close()
+    Base.metadata.bind = None
+    JoinedInheritanceBase.metadata.bind = None


### PR DESCRIPTION
With multiple Engines `Session.get_bind` needs a context so it can determine the correct Engine to return.

Fixes #57.

I added a test that somewhat mimics our setup. It's a bit ugly as it sets and removes the `bind`s of the two `Base`s.