### PR TITLE
Fix import/call inconsistency for legacy queries in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ the session/connection argument:
 
 .. code-block:: python
 
-    from sqlakeyset import select_page
+    from sqlakeyset import get_page
     with Session(engine) as s:
         q = s.query(Book).order_by(Book.author, Book.title, Book.id)
         page1 = get_page(q, per_page=20)


### PR DESCRIPTION
Hey!

I noticed a small inconsistency in `README.rst` where the imported function was different from the used one for legacy queries.