### PR TITLE
Support sqlalchemy 2.0.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ workflows:
           matrix:
             parameters:
               python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-              sqlalchemy: ["1.3.0", "1.4.0", "2.0.0"]
+              sqlalchemy: ["1.3.0", "1.4.0", "2.0.0", "2.0.11"]
       - publish:
           requires:
             - build


### PR DESCRIPTION
sqlalchemy 2.0.11 released a change to the internal structure of the Row class: https://github.com/sqlalchemy/sqlalchemy/pull/9668

This PR tries to support both sqlalchemy 2 before and after this change.