### PR TITLE
Fix double bind processing in certain cases

### DIFF
--- a/sqlakeyset/columns.py
+++ b/sqlakeyset/columns.py
@@ -111,7 +111,7 @@ class OC:
             raise ValueError  # pragma: no cover
         return OC(new_uo)
 
-    def pair_for_comparison(self, value, dialect):
+    def pair_for_comparison(self, value, dialect, apply_bind_processor: bool = False):
         """Return a pair of SQL expressions representing comparable values for
         this ordering column and a specified value.
 
@@ -122,12 +122,13 @@ class OC:
             condition for the value of this OC being past `value` in the paging
             order."""
         compval = self.comparable_value
-        # If this OC is a column with a custom type, apply the custom
-        # preprocessing to the comparsion value:
-        try:
-            value = compval.type.bind_processor(dialect)(value)  # type: ignore
-        except (TypeError, AttributeError):
-            pass
+        if apply_bind_processor:
+            # If this OC is a column with a custom type, apply the custom
+            # preprocessing to the comparison value:
+            try:
+                value = compval.type.bind_processor(dialect)(value)  # type: ignore
+            except (TypeError, AttributeError):
+                pass
         if self.is_ascending:
             return compval, value
         else:

--- a/tests/test_paging.py
+++ b/tests/test_paging.py
@@ -462,6 +462,10 @@ def test_core_result_processor(dburl):
 
 def test_core_order_by_result_processor(dburl):
     with S(dburl, echo=ECHO) as s:
+        # Check both 1-col and multicol ordering clauses (see #104):
+        selectable = select(Light.id).order_by(Light.myint)
+        check_paging_core(selectable=selectable, s=s)
+
         selectable = select(Light.id).order_by(Light.myint, Light.id)
         check_paging_core(selectable=selectable, s=s)
 

--- a/tests/test_paging_20_style.py
+++ b/tests/test_paging_20_style.py
@@ -8,6 +8,7 @@ from conftest import (
     SQLA_VERSION,
     Author,
     Book,
+    Ticket,
     S,
 )
 from test_paging import check_paging_core
@@ -16,6 +17,12 @@ if SQLA_VERSION < version.parse("1.4.0b1"):
     pytest.skip(
         "Legacy SQLAlchemy version, skipping new-style tests", allow_module_level=True
     )
+
+
+def test_uuid(dburl):
+    with S(dburl, echo=ECHO) as s:
+        q = select(Ticket).order_by(Ticket.id)
+        check_paging_core(q, s)
 
 
 def test_new_orm_query1(dburl):


### PR DESCRIPTION
Resolves #104.

When order clauses had only a single column OR the database backend did not support native tuples, bind param processing was being applied twice - once by us and once by sqlalchemy.