### PR TITLE
fix custom type implementation

### DIFF
--- a/sqlakeyset/columns.py
+++ b/sqlakeyset/columns.py
@@ -126,7 +126,8 @@ class OC:
             # If this OC is a column with a custom type, apply the custom
             # preprocessing to the comparison value:
             try:
-                value = compval.type.bind_processor(dialect)(value)  # type: ignore
+                type_impl = compval.type.dialect_impl(dialect)
+                value = type_impl.bind_processor(dialect)(value)
             except (TypeError, AttributeError):
                 pass
         if self.is_ascending:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,6 +146,23 @@ class GuardDoubleProcessing(TypeDecorator):
         return value.val
 
 
+class EnforceDialectSpecificTypes(TypeDecorator):
+    class DialectSpecificImpl(Exception):
+        pass
+
+    class InvalidTypeEngine(String):
+        def bind_processor(self, dialect):
+            raise EnforceDialectSpecificTypes.DialectSpecificImpl(
+                "Did not get the dialect specific impl."
+            )
+
+    impl = InvalidTypeEngine
+    cache_ok = True
+
+    def load_dialect_impl(self, dialect):
+        return dialect.type_descriptor(String(255))
+
+
 class Colour(enum.Enum):
     red = 0
     green = 1
@@ -191,7 +208,7 @@ class Book(Base):
 class Author(Base):
     __tablename__ = "author"
     id = Column(Integer, primary_key=True)
-    name = Column(String(255), nullable=False)
+    name = Column(EnforceDialectSpecificTypes, nullable=False)
     books = relationship("Book", backref="author")
     info = Column(String(255), nullable=False)
 


### PR DESCRIPTION
Attempted fix to load the dialect specific `impl` for custom `TypeDecorator` types.

Here is an example with comments indicating what the previous error was and what the fix is. Let me know if you would like additional explanation. The example is verbose cause I thought it might be useful to create a test for this - so I tried to add all the necessary parts.

```python
import datetime
from typing import Any, ClassVar

from sqlalchemy import DateTime, Dialect, TypeDecorator
from sqlalchemy.dialects import sqlite
from sqlalchemy.ext.asyncio import (
    AsyncAttrs,
)
from sqlalchemy.orm import (
    DeclarativeBase,
    Mapped,
    MappedAsDataclass,
    mapped_column,
)
from sqlalchemy.schema import MetaData
from sqlalchemy.types import TypeEngine


class UtcDateTime(TypeDecorator):
    # previously only the DateTime type was returned.
    # load_dialect_impl was never called
    impl = DateTime(timezone=True)
    cache_ok = True

    # now load_dialect_impl is called and the correct type is returned
    def load_dialect_impl(self, dialect: Dialect) -> TypeEngine[Any]:
        if dialect.name == "sqlite":
            return sqlite.DATETIME(
                timezone=True,
                storage_format="%(year)04d-%(month)02d-%(day)02d %(hour)02d:%(minute)02d:%(second)02d.%(microsecond)03d",
                regexp=r"(?P<year>\d+)-(?P<month>\d+)-(?P<day>\d+) (?P<hour>\d+):(?P<minute>\d+):(?P<second>\d+)\.(?P<microsecond>\d+)",
            )

        return DateTime(timezone=True)

    def process_bind_param(self, value: Any, dialect: Dialect):
        if value is not None:
            if not isinstance(value, datetime.datetime):
                raise TypeError("expected datetime.datetime, not " + repr(value))
            if value.tzinfo is None:
                raise ValueError("naive datetime are not supported")
            return value.astimezone(datetime.timezone.utc)
        return None

    def process_result_value(self, value: Any, dialect: Dialect):
        if value is not None:
            if value.tzinfo is None:
                value = value.replace(tzinfo=datetime.timezone.utc)
            else:
                value = value.astimezone(datetime.timezone.utc)
        return value


class Base(MappedAsDataclass, AsyncAttrs, DeclarativeBase):
    metadata = MetaData(
        naming_convention={
            "ix": "ix_%(column_0_label)s",
            "uq": "uq_%(table_name)s_%(column_0_name)s",
            "ck": "ck_%(table_name)s_%(constraint_name)s",
            "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
            "pk": "pk_%(table_name)s",
        },
    )
    type_annotation_map: ClassVar[dict[type, Any]] = {datetime.datetime: UtcDateTime}


class DBUser(
    Base,
):
    __tablename__ = "user"
    id: Mapped[int] = mapped_column(primary_key=True)
    created_at: Mapped[datetime.datetime] = mapped_column(nullable=False)

```