### PR TITLE
Fix custom types in asyncpg

### DIFF
--- a/sqlakeyset/paging.py
+++ b/sqlakeyset/paging.py
@@ -14,20 +14,21 @@ from typing import (
     Union,
     overload,
 )
-from typing_extensions import Literal  # to keep python 3.7 support
 
-from sqlalchemy import tuple_, and_, or_
+from sqlalchemy import and_, or_, tuple_
 from sqlalchemy.engine import Connection
 from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.query import Query
 from sqlalchemy.sql.expression import ColumnElement
 from sqlalchemy.sql.selectable import Select
+from typing_extensions import Literal  # to keep python 3.7 support
 
 from .columns import OC, MappedOrderColumn, find_order_key, parse_ob_clause
 from .results import Page, Paging, unserialize_bookmark
 from .serial import InvalidPage
 from .sqla import (
+    Row,
     core_coerce_row,
     core_result_type,
     get_bind,
@@ -37,14 +38,13 @@ from .sqla import (
     orm_query_keys,
     orm_result_type,
     orm_to_selectable,
-    Row,
 )
 from .types import Keyset, Marker, MarkerLike
-
 
 _TP = TypeVar("_TP", bound=Tuple[Any, ...])
 
 PER_PAGE_DEFAULT = 10
+
 
 def can_use_native_tuples(dialect: Dialect):
     # SQL drivers built-in to sqlalchemy that support native tuple comparison and seem
@@ -161,8 +161,7 @@ def prepare_paging(
     backwards: bool,
     orm: Literal[True],
     dialect: Dialect,
-) -> _PagingQuery:
-    ...
+) -> _PagingQuery: ...
 
 
 @overload
@@ -173,8 +172,7 @@ def prepare_paging(
     backwards: bool,
     orm: Literal[False],
     dialect: Dialect,
-) -> _PagingSelect:
-    ...
+) -> _PagingSelect: ...
 
 
 def prepare_paging(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,8 @@
 import enum
+import uuid
 from datetime import timedelta
 from functools import partial
 from random import randrange
-import uuid
 
 import arrow
 import pytest
@@ -22,13 +22,12 @@ from sqlalchemy import select as _select
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import column_property, relationship
 from sqlalchemy.types import TypeDecorator
+from sqlalchemy_utils import ArrowType
 from sqlbag import S as _S
 from sqlbag import temporary_database
 
-from sqlakeyset.sqla import SQLA_VERSION
 from sqlakeyset import custom_bookmark_type
-
-from sqlalchemy_utils import ArrowType
+from sqlakeyset.sqla import SQLA_VERSION
 
 SQLA2 = SQLA_VERSION >= version.parse("1.4")
 if not SQLA2:
@@ -332,7 +331,13 @@ def _dburl(request):
 
     with temporary_database(request.param, host="localhost") as dburl:
         with S(dburl) as s:
-            Base.metadata.create_all(s.connection())
+            if request.param == "postgresql":
+                tables = None
+            else:
+                tables = [
+                    t for k, t in Base.metadata.tables.items() if not k.startswith("pg_only_")
+                ]
+            Base.metadata.create_all(s.connection(), tables=tables)
             s.add_all(data)
             s.execute(insert(Widget).values(widgets))
         yield dburl

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -335,7 +335,9 @@ def _dburl(request):
                 tables = None
             else:
                 tables = [
-                    t for k, t in Base.metadata.tables.items() if not k.startswith("pg_only_")
+                    t
+                    for k, t in Base.metadata.tables.items()
+                    if not k.startswith("pg_only_")
                 ]
             Base.metadata.create_all(s.connection(), tables=tables)
             s.add_all(data)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,15 +1,19 @@
-from contextlib import asynccontextmanager
 import json
 import re
+from contextlib import asynccontextmanager
 
 import pytest
 import pytest_asyncio
-from sqlalchemy.types import UserDefinedType
 from conftest import SQLA_VERSION, Author, Base, Book, Ticket
 from packaging import version
-from sqlalchemy import JSON, Column, Integer, String, desc, orm, select
+from sqlalchemy import Column, Integer, desc, orm, select
+from sqlalchemy.types import UserDefinedType
 
-from sqlakeyset.results import custom_bookmark_type, serialize_bookmark, unserialize_bookmark
+from sqlakeyset.results import (
+    custom_bookmark_type,
+    serialize_bookmark,
+    unserialize_bookmark,
+)
 
 if SQLA_VERSION < version.parse("1.4.0"):
     pytest.skip(
@@ -33,11 +37,13 @@ class StringifiedJSON(UserDefinedType):
     def bind_processor(self, dialect):
         def process(value):
             return json.dumps(value)
+
         return process
 
     def result_processor(self, dialect, coltype):
         def process(value):
             return value
+
         return process
 
     def get_col_spec(self, **kw):
@@ -50,7 +56,9 @@ class Jason(Base):
     id = Column(Integer, primary_key=True)
     content = Column(StringifiedJSON, nullable=False)
 
+
 custom_bookmark_type(dict, "D", json.loads, json.dumps)
+
 
 @asynccontextmanager
 async def _make_async_session(dburl):
@@ -65,18 +73,22 @@ async def _make_async_session(dburl):
 
     async with sessionmaker() as s:
         if pg:
-            s.add_all([
-                Jason(content={"hello": "world"}),
-                Jason(content={}),
-                Jason(content={"video": "games"}),
-                Jason(content={"potato": "salad"}),
-            ])
+            s.add_all(
+                [
+                    Jason(content={"hello": "world"}),
+                    Jason(content={}),
+                    Jason(content={"video": "games"}),
+                    Jason(content={"potato": "salad"}),
+                ]
+            )
         yield s
+
 
 @pytest_asyncio.fixture
 async def async_session(dburl):
     async with _make_async_session(dburl) as s:
         yield s
+
 
 @pytest_asyncio.fixture
 async def asyncpg_session(pg_only_dburl):
@@ -135,6 +147,7 @@ async def test_async_orm_query1(async_session):
 async def test_uuid(async_session):
     q = select(Ticket).order_by(Ticket.id)
     await check_paging_async(q, async_session)
+
 
 @pytest.mark.asyncio
 async def test_bind_processor(asyncpg_session):

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,12 +1,18 @@
+import json
 import re
 
 import pytest
 import pytest_asyncio
-from conftest import SQLA_VERSION, Author, Book
+from conftest import SQLA_VERSION, Author, Base, Book, Ticket
 from packaging import version
-from sqlalchemy import desc, orm, select
+from sqlalchemy import Column, Integer, desc, orm, select
+from sqlalchemy.types import UserDefinedType
 
-from sqlakeyset.results import serialize_bookmark, unserialize_bookmark
+from sqlakeyset.results import (
+    custom_bookmark_type,
+    serialize_bookmark,
+    unserialize_bookmark,
+)
 
 if SQLA_VERSION < version.parse("1.4.0"):
     pytest.skip(
@@ -24,6 +30,35 @@ ASYNC_PROTOS = {
 }
 
 
+class StringInt(UserDefinedType):
+    cache_ok = True
+
+    def bind_processor(self, dialect):
+        def process(value):
+            return str(value)
+
+        return process
+
+    def result_processor(self, dialect, coltype):
+        def process(value):
+            return value
+
+        return process
+
+    def get_col_spec(self, **kw):
+        return "INT"
+
+
+class Wat(Base):
+    __tablename__ = "wat"
+
+    id = Column(Integer, primary_key=True)
+    num = Column(StringInt, nullable=False)
+
+
+custom_bookmark_type(dict, "D", json.loads, json.dumps)
+
+
 @pytest_asyncio.fixture
 async def async_session(dburl):
     for k, v in ASYNC_PROTOS.items():
@@ -35,6 +70,7 @@ async def async_session(dburl):
         sessionmaker = orm.sessionmaker(engine, class_=asa.AsyncSession)
 
     async with sessionmaker() as s:
+        s.add_all([Wat(num=i % 3) for i in range(20)])
         yield s
 
 
@@ -82,4 +118,16 @@ async def check_paging_async(selectable, s):
 async def test_async_orm_query1(async_session):
     spec = [desc(Book.b), Book.d, Book.id]
     q = select(Book, Author, Book.id).outerjoin(Author).order_by(*spec)
+    await check_paging_async(q, async_session)
+
+
+@pytest.mark.asyncio
+async def test_uuid(async_session):
+    q = select(Ticket).order_by(Ticket.id)
+    await check_paging_async(q, async_session)
+
+
+@pytest.mark.asyncio
+async def test_bind_processor(async_session):
+    q = select(Wat).order_by(Wat.num, Wat.id)
     await check_paging_async(q, async_session)


### PR DESCRIPTION
Resolves #112

Disable native SQL tuples for non-psycopg2 postgresql drivers, which use render_bind_casts and thus break our workaround for https://github.com/sqlalchemy/sqlalchemy/issues/8992

There are still probably other cases where the tuple rendering bug breaks us; but at this point I'd rather just address reported bugs rather than trying to make a big change that might break other things.
The upstream bug is marked as high priority so hopefuly it's fixed soon.