### PR TITLE
Test documentation builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,11 +8,9 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
+    # If you update the Python version here,
+    # update `[testenv:docs]/base_python` in `tox.ini` as well.
     python: "3.11"
-    # You can also specify other tool versions:
-    # nodejs: "20"
-    # rust: "1.70"
-    # golang: "1.20"
 
 # Build documentation in the "doc/" directory with Sphinx
 sphinx:

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,1 +1,3 @@
+sphinx
+sphinx_rtd_theme
 -e .

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -53,4 +53,4 @@ html_theme = "sphinx_rtd_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+html_static_path = []

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,13 @@
-# Tox (http://tox.testrun.org/) is a tool for running tests
-# in multiple virtualenvs. This configuration file will run the
-# test suite on all supported python versions. To use it, "pip install tox"
-# and then run "tox" from this directory.
+# Tox (https://tox.wiki/) is a tool for running commands
+# in isolated Python virtual environments.
+# This configuration file defines how the complete test suite runs.
+# To use it, "pip install tox" and then run "tox" from this directory.
 
 [tox]
-envlist = py27,py36
-toxworkdir = {homedir}/.toxfiles{toxinidir}
+envlist =
+    py27,py36
+    docs
+
 
 [testenv]
 commands = py.test \
@@ -13,6 +15,17 @@ commands = py.test \
 
 deps =
     -rrequirements-dev.txt
+
+
+[testenv:docs]
+# If you update the Python version here,
+# update `build.tools.python.version` in `.readthedocs.yaml` as well.
+base_python = py3.11
+deps =
+    -rdoc/requirements.txt
+commands =
+    sphinx-build -j auto -aEWb html --keep-going doc/source build/html/
+
 
 [flake8]
 extend-ignore = E501, E731


### PR DESCRIPTION
[ReadTheDocs hasn't built the documentation in over a year](https://app.readthedocs.org/projects/sqlakeyset/builds/).

To help ensure that the documentation _can_ build cleanly, this PR introduces a new tox build environment, `docs`, which tests that the documentation can build.

It also fixes a single warning issued by the new doc tests:

```
WARNING: html_static_path entry '_static' does not exist
```

----

> [!NOTE]
>
> While working on this, it became clear that `tox.ini` is not maintained (Python 2.7 and 3.6 are the only defined Python versions to test). This can be addressed in a separate PR.
>
> Also, it is strongly recommended that `doc/requirements.txt` pin exact dependency versions.
> This PR does not address build reproducibility; it simply introduces testing of the documentation builds.