### PR TITLE
Improve type hint for Keyset to avoid Pyright "reportUnknownVariableType"  error

### DIFF
--- a/sqlakeyset/types.py
+++ b/sqlakeyset/types.py
@@ -1,9 +1,9 @@
 """Keyset/Marker types"""
 from __future__ import annotations
 
-from typing import Optional, Tuple, NamedTuple, Union
+from typing import Optional, Tuple, NamedTuple, Union, Any
 
-Keyset = Tuple
+Keyset = Tuple[Any, ...]
 """A tuple with as many entries as you have sort keys, representing a place in
 a sorted resultset."""
 


### PR DESCRIPTION
Hi,

Many of us who use `sqlakeyset `work with VSCode and Pylance (Pyright) to keep our code clean and error-free. I’m currently working on a project that enforces strict type checking with Pyright, and I’ve noticed that some functions, such as `select_page`, define the type `Keyset`, which is a copy of `Tuple`.

That part is fine, but Pyright infers this as `Tuple[Unknown]`, which triggers the `"reportUnknownVariableType"` error. This happens even when using the functions as intended.

After testing a bit, I found that redefining Keyset as `Tuple[Any, ...] `fixes the error. Since Keyset can hold any value depending on how the table is defined, and `Any `is more specific than `Unknown`, this change seems both accurate and sufficient.

Let me know what you think — I’d be happy to submit a PR with this fix if it helps.

Thanks again for such a wonderful module!

Best regards,

Juan