### PR TITLE
fix(paging): handle boolean column on order by clause

### DIFF
--- a/sqlakeyset/paging.py
+++ b/sqlakeyset/paging.py
@@ -20,6 +20,7 @@ from sqlalchemy.engine import Connection
 from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.query import Query
+from sqlalchemy.sql import cast
 from sqlalchemy.sql.expression import ColumnElement
 from sqlalchemy.sql.selectable import Select
 from sqlalchemy.sql.sqltypes import Boolean
@@ -60,33 +61,23 @@ def can_use_native_tuples(dialect: Dialect):
     return False
 
 
-def _cast_if_bool(comparator_1: Any, comparator_2: Any) -> tuple[Any, Any]:
+def _is_bool(a) -> bool:
+    """Check if a value or SQL clause has type bool."""
+    if isinstance(a, bool):
+        return True
+    if isinstance(a, ColumnElement):
+        return isinstance(a.type, Boolean)
+    return False
+
+
+def _cast_if_bool(a: Any, b: Any) -> tuple[Any, Any]:
     """Cast boolean values/columns to integers for comparison.
     SQLAlchemy doesn't allow <, <=, >, >= operators on boolean columns.
     """
-    # Identify which is the column and which is the value
-    column: ColumnElement
-    value: Any
-    if isinstance(comparator_1, ColumnElement):
-        column, value = comparator_1, comparator_2
+    if _is_bool(a) or _is_bool(b):
+        return cast(a, Integer), cast(b, Integer)
     else:
-        column, value = comparator_2, comparator_1
-
-    # Check if this is a boolean column/value that needs casting
-    is_bool_value = isinstance(value, bool)
-    is_bool_column = isinstance(column.type, Boolean)
-
-    if is_bool_value or is_bool_column:
-        # Cast column to Integer and convert value to int
-        casted_column = column.cast(Integer)
-        int_value = int(value)
-        # Return in the correct order
-        if isinstance(comparator_1, ColumnElement):
-            return casted_column, int_value
-        else:
-            return int_value, casted_column
-
-    return comparator_1, comparator_2
+        return a, b
 
 
 def compare_tuples(lesser: Sequence, greater: Sequence) -> ColumnElement[bool]:

--- a/sqlakeyset/paging.py
+++ b/sqlakeyset/paging.py
@@ -15,13 +15,14 @@ from typing import (
     overload,
 )
 
-from sqlalchemy import and_, or_, tuple_
+from sqlalchemy import Integer, and_, or_, tuple_
 from sqlalchemy.engine import Connection
 from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.query import Query
 from sqlalchemy.sql.expression import ColumnElement
 from sqlalchemy.sql.selectable import Select
+from sqlalchemy.sql.sqltypes import Boolean
 from typing_extensions import Literal  # to keep python 3.7 support
 
 from .columns import OC, MappedOrderColumn, find_order_key, parse_ob_clause
@@ -59,6 +60,35 @@ def can_use_native_tuples(dialect: Dialect):
     return False
 
 
+def _cast_if_bool(comparator_1: Any, comparator_2: Any) -> tuple[Any, Any]:
+    """Cast boolean values/columns to integers for comparison.
+    SQLAlchemy doesn't allow <, <=, >, >= operators on boolean columns.
+    """
+    # Identify which is the column and which is the value
+    column: ColumnElement
+    value: Any
+    if isinstance(comparator_1, ColumnElement):
+        column, value = comparator_1, comparator_2
+    else:
+        column, value = comparator_2, comparator_1
+
+    # Check if this is a boolean column/value that needs casting
+    is_bool_value = isinstance(value, bool)
+    is_bool_column = isinstance(column.type, Boolean)
+
+    if is_bool_value or is_bool_column:
+        # Cast column to Integer and convert value to int
+        casted_column = column.cast(Integer)
+        int_value = int(value)
+        # Return in the correct order
+        if isinstance(comparator_1, ColumnElement):
+            return casted_column, int_value
+        else:
+            return int_value, casted_column
+
+    return comparator_1, comparator_2
+
+
 def compare_tuples(lesser: Sequence, greater: Sequence) -> ColumnElement[bool]:
     """Given two sequences of equal length (whose entries can be SQL clauses or
     simple values), create a simple SQL clause equivalent to the lexicographic
@@ -78,12 +108,14 @@ def compare_tuples(lesser: Sequence, greater: Sequence) -> ColumnElement[bool]:
 
     # Form the innermost comparison,
     # which will also be the only comparison if the tuples are of length 1
-    clause = lesser[-1] < greater[-1]
+    l_a, g_a = _cast_if_bool(lesser[-1], greater[-1])
+    clause = l_a < g_a
 
     # Wrap with higher precedence comparisons on earlier columns
     for idx in reversed(range(len(lesser) - 1)):
-        clause = or_(lesser[idx] < greater[idx], clause)
-        clause = and_(lesser[idx] <= greater[idx], clause)
+        l_a, g_a = _cast_if_bool(lesser[idx], greater[idx])
+        clause = or_(l_a < g_a, clause)
+        clause = and_(l_a <= g_a, clause)
     return clause
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import arrow
 import pytest
 from packaging import version
 from sqlalchemy import (
+    Boolean,
     Column,
     Enum,
     ForeignKey,
@@ -185,6 +186,7 @@ class Light(Base):
     intensity = Column(Integer, nullable=False)
     colour = Column(Enum(Colour), nullable=False)
     myint = Column(GuardDoubleProcessing, nullable=False)
+    is_switched = Column(Boolean, nullable=False, default=True)
 
 
 class Book(Base):

--- a/tests/test_paging.py
+++ b/tests/test_paging.py
@@ -489,6 +489,12 @@ def test_orm_order_by_enum(no_mysql_dburl):
         check_paging_orm(q=q)
 
 
+def test_orm_order_by_boolean(no_mysql_dburl):
+    with S(no_mysql_dburl, echo=ECHO) as s:
+        q = s.query(Light.id).order_by(Light.is_switched, Light.id)
+        check_paging_orm(q=q)
+
+
 def test_orm_result_processor(dburl):
     with S(dburl, echo=ECHO) as s:
         q = s.query(Light.id, Light.myint).order_by(Light.intensity, Light.id)


### PR DESCRIPTION
The boolean case is broken as SQLAlchemy doesn't allow <, <=, >, >= operators on boolean columns. The column must be cast explicitley to integer as well as the value.

See [issues 122](https://github.com/djrobstep/sqlakeyset/issues/122) for full details.